### PR TITLE
Slide deck template

### DIFF
--- a/app/Document.js
+++ b/app/Document.js
@@ -1,3 +1,4 @@
+/* eslint new-cap: 0 */
 import { Record } from 'immutable';
 import { Config } from './Config';
 import uuid from 'uuid';

--- a/app/Store.js
+++ b/app/Store.js
@@ -101,7 +101,7 @@ export default class Store {
                 last_modified_locally: document.get('last_modified_locally'),
                 template: document.get('template')
               }),
-              secret: secret
+              secret
             });
           });
       })
@@ -139,7 +139,7 @@ export default class Store {
     return this.update(
       new Document({
         uuid: previousDocument.get('uuid'),
-        content: content,
+        content,
         last_modified: previousDocument.get('last_modified'),
         last_modified_locally: previousDocument.get('last_modified_locally'),
         template: previousDocument.get('template'),
@@ -156,7 +156,7 @@ export default class Store {
         content: previousDocument.get('content'),
         last_modified: previousDocument.get('last_modified'),
         last_modified_locally: previousDocument.get('last_modified_locally'),
-        template: template
+        template
       })
     );
   }
@@ -217,7 +217,7 @@ export default class Store {
                 this._setState(
                   {
                     document: updatedDocument,
-                    secret: secret
+                    secret
                   },
                   Events.UPDATE_WITHOUT_CONFLICT,
                   {
@@ -362,7 +362,7 @@ export default class Store {
                   last_modified_locally: null,
                   template: res.body.template || ''
                 }),
-                secret: secret
+                secret
               },
               Events.SYNCHRONIZE
             );

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -154,7 +154,10 @@ export default class App extends Component {
   render() {
     return (
       <div className="layout">
-        <Header />
+        <Header
+          template={this.state.document.get('template')}
+          onUpdateTemplate={this.updateTemplate.bind(this)}
+        />
         <MessageBoxes
           messages={this.state.messages}
           closeMessageBox={this.removeMessage.bind(this)}
@@ -164,7 +167,6 @@ export default class App extends Component {
           content={this.state.document.get('content')}
           template={this.state.document.get('template')}
           onUpdateContent={this.updateContent.bind(this)}
-          onUpdateTemplate={this.updateTemplate.bind(this)}
         />
         <Footer version={this.props.version} />
       </div>

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -114,6 +114,28 @@ export default class App extends Component {
     });
   }
 
+  togglePresentationMode() {
+    if (
+      (!document.fullscreenElement) &&
+      (!document.webkitFullscreenElement) &&
+      (!document.mozFullScreenElement) &&
+      (!document.msFullscreenElement)
+    ) {
+      const element = document.getElementsByClassName('preview')[0];
+
+      // Switch to fullscreen
+      const requestMethod = element.requestFullScreen ||
+                            element.webkitRequestFullscreen ||
+                            element.webkitRequestFullScreen ||
+                            element.mozRequestFullScreen ||
+                            element.msRequestFullscreen;
+
+      if (requestMethod) {
+        requestMethod.apply(element);
+      }
+    }
+  }
+
   loadAndRedirect(doc, uri, message) {
     if (message) {
       this.state.messages.push(message);
@@ -155,6 +177,7 @@ export default class App extends Component {
     return (
       <div className="layout">
         <Header
+          onTogglePresentationMode={this.togglePresentationMode.bind(this)}
           template={this.state.document.get('template')}
           onUpdateTemplate={this.updateTemplate.bind(this)}
         />

--- a/app/components/Editor.jsx
+++ b/app/components/Editor.jsx
@@ -24,6 +24,12 @@ export default class Editor extends Component {
     };
   }
 
+  componentDidUpdate() {
+    if (window.Reveal) {
+      window.Reveal.sync();
+    }
+  }
+
   updatePosition(newPos) {
     this.setState({ pos: newPos });
   }
@@ -46,12 +52,6 @@ export default class Editor extends Component {
     }
 
     this.updateMode(newMode);
-  }
-
-  componentDidUpdate() {
-    if (window.Reveal) {
-      window.Reveal.sync();
-    }
   }
 
   render() {

--- a/app/components/Editor.jsx
+++ b/app/components/Editor.jsx
@@ -3,7 +3,6 @@ import Loader from 'react-loader';
 
 import Markdown from './Markdown';
 import Preview from './Preview';
-import TemplateForm from './TemplateForm';
 import VerticalHandler from './VerticalHandler';
 
 const { bool, func, string } = PropTypes;
@@ -60,10 +59,6 @@ export default class Editor extends Component {
         loaded={this.props.loaded}
         loadedClassName={`editor ${this.state.mode}`}
       >
-        <TemplateForm
-          template={this.props.template}
-          doUpdateTemplate={this.props.onUpdateTemplate}
-        />
         <Markdown
           raw={this.props.content}
           onChange={this.props.onUpdateContent}
@@ -87,8 +82,7 @@ Editor.propTypes = {
   loaded: bool.isRequired,
   content: string.isRequired,
   template: string.isRequired,
-  onUpdateContent: func.isRequired,
-  onUpdateTemplate: func.isRequired
+  onUpdateContent: func.isRequired
 };
 
 Editor.contextTypes = {

--- a/app/components/Editor.jsx
+++ b/app/components/Editor.jsx
@@ -48,6 +48,12 @@ export default class Editor extends Component {
     this.updateMode(newMode);
   }
 
+  componentDidUpdate() {
+    if (window.Reveal) {
+      window.Reveal.sync();
+    }
+  }
+
   render() {
     return (
       <Loader

--- a/app/components/Editor.jsx
+++ b/app/components/Editor.jsx
@@ -26,7 +26,7 @@ export default class Editor extends Component {
 
   componentDidUpdate() {
     if (window.Reveal) {
-      window.Reveal.sync();
+      window.Reveal.layout();
     }
   }
 

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -8,7 +8,21 @@ const Footer = (props) =>
   <footer className="main">
     <div className="version">
       <span className="git-ref">
-        <i className="fa fa-code-fork"></i>&nbsp;{props.version}
+        <i className="fa fa-code-fork"></i>&nbsp;&nbsp;{props.version}
+      </span>
+    </div>
+
+    <div className="help">
+      <span className="help-link">
+        <i className="fa fa-book"></i>
+        &nbsp;&nbsp;
+        <a
+          href="https://github.com/TailorDev/monod/blob/slidedeck/doc/writing.md"
+          title="The Monod documentation"
+          target="_blank"
+        >
+          Documentation
+        </a>
       </span>
     </div>
 

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -8,6 +8,7 @@ const Header = (props) =>
   <header className="main">
     <h1>Monod <small>The Markdown Editor</small></h1>
     <Toolbar
+      onTogglePresentationMode={props.onTogglePresentationMode}
       template={props.template}
       onUpdateTemplate={props.onUpdateTemplate}
     />
@@ -15,6 +16,7 @@ const Header = (props) =>
 ;
 
 Header.propTypes = {
+  onTogglePresentationMode: func.isRequired,
   template: string.isRequired,
   onUpdateTemplate: func.isRequired
 };

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -1,8 +1,22 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
+import Toolbar from './Toolbar';
 
-export default () => (
+const { func, string } = PropTypes;
+
+const Header = (props) =>
   <header className="main">
     <h1>Monod <small>The Markdown Editor</small></h1>
+    <Toolbar
+      template={props.template}
+      onUpdateTemplate={props.onUpdateTemplate}
+    />
   </header>
-);
+;
+
+Header.propTypes = {
+  template: string.isRequired,
+  onUpdateTemplate: func.isRequired
+};
+
+export default Header;

--- a/app/components/Markdown.jsx
+++ b/app/components/Markdown.jsx
@@ -1,3 +1,4 @@
+/* eslint new-cap: 0 */
 import React, { Component, PropTypes } from 'react';
 import MarkdownLoader from './loaders/Markdown';
 import CodeMirror from 'codemirror';

--- a/app/components/Preview.jsx
+++ b/app/components/Preview.jsx
@@ -99,6 +99,13 @@ export default class Preview extends Component {
         this.markdownIt.use(plugin);
       });
 
+      // custom containers must be explicitly defined
+      this.markdownIt.use(deps.markdownItContainer, 'small', {
+        render: (tokens, idx) => {
+          return 1 === tokens[idx].nesting ? '<small>\n' : '</small>\n';
+        }
+      });
+
       this.emojione = deps.emojione;
       this.emojione.ascii = true;
       this.emojione.sprites = true;

--- a/app/components/Preview.jsx
+++ b/app/components/Preview.jsx
@@ -11,7 +11,7 @@ const { array, func, number, object, string } = PropTypes;
 
 import 'emojione/assets/sprites/emojione.sprites.css';
 
-class PreviewChunk extends Component {
+export class PreviewChunk extends Component {
 
   shouldComponentUpdate(nextProps) {
     // It looks like `attrs` is modified by hljs on `render()`, which

--- a/app/components/Preview.jsx
+++ b/app/components/Preview.jsx
@@ -1,4 +1,4 @@
-/* eslint no-param-reassign: 1, array-callback-return: 1 */
+/* eslint no-param-reassign: 0, array-callback-return: 0, react/no-multi-comp: 0 */
 import React, { PropTypes, Component } from 'react';
 import ReactDOM from 'react-dom';
 import PreviewLoader from './loaders/Preview';
@@ -116,7 +116,7 @@ export default class Preview extends Component {
       return;
     }
 
-    if (this.props.pos !== nextProps.pos || nextProps.pos === 1) {
+    if (this.props.pos !== nextProps.pos || 1 === nextProps.pos) {
       if (this.requestAnimationId) {
         window.cancelAnimationFrame(this.requestAnimationId);
         this.requestAnimationId = false;
@@ -153,9 +153,9 @@ export default class Preview extends Component {
           i < start ||
           !(
             // We are (NOT) closing a nested block
-            (tokens[i].level === 0 && tokens[i].nesting === -1) ||
+            (0 === tokens[i].level && -1 === tokens[i].nesting) ||
             // We are (NOT) in a root block
-            (tokens[i].level === 0 && tokens[i].nesting === 0)
+            (0 === tokens[i].level && 0 === tokens[i].nesting)
           )) {
         continue;
       }

--- a/app/components/Sync.jsx
+++ b/app/components/Sync.jsx
@@ -22,7 +22,7 @@ export default class Sync extends Component {
 
       if (0 < counter) {
         counter--;
-        this.setState({ counter: counter });
+        this.setState({ counter });
 
         if (0 === counter) {
           this.setState({ counter: DEFAULT_DURATION });
@@ -52,9 +52,9 @@ export default class Sync extends Component {
 
       this.setState({
         counter: duration,
-        duration: duration,
+        duration,
         offline: true,
-        displayCounter: displayCounter
+        displayCounter
       });
     });
   }

--- a/app/components/TemplateForm.jsx
+++ b/app/components/TemplateForm.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import Letter from './templates/Letter';
 import Invoice from './templates/Invoice';
 import Report from './templates/Report';
+import Slidedeck from './templates/Slidedeck';
 
 const { string, func } = PropTypes;
 
@@ -10,7 +11,8 @@ export const Templates = [
   { id: '', name: 'No template', component: {} },
   { id: 'letter', name: 'Letter', component: Letter },
   { id: 'invoice', name: 'Invoice', component: Invoice },
-  { id: 'report', name: 'Report', component: Report }
+  { id: 'report', name: 'Report', component: Report },
+  { id: 'slidedeck', name: 'Slide deck', component: Slidedeck },
 ];
 
 const TemplateForm = (props) =>

--- a/app/components/Toolbar.jsx
+++ b/app/components/Toolbar.jsx
@@ -6,6 +6,15 @@ const { func, string } = PropTypes;
 
 const Toolbar = (props) =>
   <div id="toolbar">
+    <div className="actions">
+      <button
+        className="action fullscreen"
+        title="Presentation mode"
+        onClick={props.onTogglePresentationMode}
+      >
+        <i className="fa fa-play-circle" aria-hidden="true"></i>
+      </button>
+    </div>
     <TemplateForm
       template={props.template}
       doUpdateTemplate={props.onUpdateTemplate}
@@ -14,6 +23,7 @@ const Toolbar = (props) =>
 ;
 
 Toolbar.propTypes = {
+  onTogglePresentationMode: func.isRequired,
   template: string.isRequired,
   onUpdateTemplate: func.isRequired
 };

--- a/app/components/Toolbar.jsx
+++ b/app/components/Toolbar.jsx
@@ -1,0 +1,21 @@
+import React, { PropTypes } from 'react';
+
+import TemplateForm from './TemplateForm';
+
+const { func, string } = PropTypes;
+
+const Toolbar = (props) =>
+  <div id="toolbar">
+    <TemplateForm
+      template={props.template}
+      doUpdateTemplate={props.onUpdateTemplate}
+    />
+  </div>
+;
+
+Toolbar.propTypes = {
+  template: string.isRequired,
+  onUpdateTemplate: func.isRequired
+};
+
+export default Toolbar;

--- a/app/components/__tests__/Editor-test.js
+++ b/app/components/__tests__/Editor-test.js
@@ -32,7 +32,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -46,7 +45,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -62,7 +60,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={spy}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -80,7 +77,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -95,7 +91,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -110,7 +105,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -126,7 +120,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={spy}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -143,7 +136,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -164,7 +156,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -191,7 +182,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );
@@ -212,7 +202,6 @@ describe('<Editor />', () => {
         content={''}
         onUpdateContent={() => {}}
         template={''}
-        onUpdateTemplate={() => {}}
       />,
       { context }
     );

--- a/app/components/__tests__/Header-test.js
+++ b/app/components/__tests__/Header-test.js
@@ -13,6 +13,7 @@ describe('<Header />', () => {
   it('renders a header element', () => {
     const wrapper = shallow(
       <Header
+        onTogglePresentationMode={() => {}}
         template={''}
         onUpdateTemplate={() => {}}
       />

--- a/app/components/__tests__/Preview-test.js
+++ b/app/components/__tests__/Preview-test.js
@@ -17,6 +17,7 @@ import mditIns from 'markdown-it-ins';
 import mditAbbr from 'markdown-it-abbr';
 import mditKatex from 'markdown-it-katex';
 import mditContainer from 'markdown-it-container';
+import mditClassy from 'markdown-it-classy';
 
 // see: https://github.com/mochajs/mocha/issues/1847
 const { before, describe, it, Promise } = global;
@@ -42,6 +43,7 @@ describe('<Preview />', () => {
           mditIns,
           mditAbbr,
           mditKatex,
+          mditClassy,
         ],
         markdownItContainer: mditContainer,
         hljs: hljs,
@@ -596,6 +598,23 @@ describe('<Preview />', () => {
 
     setTimeout(() => {
       expect(wrapper.html()).to.contain('<small>\n<p>foo</p>\n</small>');
+
+      done();
+    }, 5);
+  });
+
+  it('supports CSS custom classes', (done) => {
+    const wrapper = mount(
+      <Preview
+        raw={'hello\n{css-class}'}
+        pos={0}
+        previewLoader={previewLoader}
+        template={''}
+      />
+    );
+
+    setTimeout(() => {
+      expect(wrapper.html()).to.contain('<p class="css-class">hello</p>');
 
       done();
     }, 5);

--- a/app/components/__tests__/Preview-test.js
+++ b/app/components/__tests__/Preview-test.js
@@ -16,6 +16,7 @@ import mditMark from 'markdown-it-mark';
 import mditIns from 'markdown-it-ins';
 import mditAbbr from 'markdown-it-abbr';
 import mditKatex from 'markdown-it-katex';
+import mditContainer from 'markdown-it-container';
 
 // see: https://github.com/mochajs/mocha/issues/1847
 const { before, describe, it, Promise } = global;
@@ -42,6 +43,7 @@ describe('<Preview />', () => {
           mditAbbr,
           mditKatex,
         ],
+        markdownItContainer: mditContainer,
         hljs: hljs,
         emojione: emojione
       });
@@ -577,6 +579,23 @@ describe('<Preview />', () => {
 
     setTimeout(() => {
       expect(wrapper.html()).to.contain('class="katex"');
+
+      done();
+    }, 5);
+  });
+
+  it('supports custom container: small', (done) => {
+    const wrapper = mount(
+      <Preview
+        raw={':::small\nfoo\n:::'}
+        pos={0}
+        previewLoader={previewLoader}
+        template={''}
+      />
+    );
+
+    setTimeout(() => {
+      expect(wrapper.html()).to.contain('<small>\n<p>foo</p>\n</small>');
 
       done();
     }, 5);

--- a/app/components/__tests__/Toolbar-test.js
+++ b/app/components/__tests__/Toolbar-test.js
@@ -13,6 +13,7 @@ describe('<Toolbar />', () => {
   it('renders the application\'s toolbar', () => {
     const wrapper = shallow(
       <Toolbar
+        onTogglePresentationMode={() => {}}
         template={''}
         onUpdateTemplate={() => {}}
       />);

--- a/app/components/__tests__/Toolbar-test.js
+++ b/app/components/__tests__/Toolbar-test.js
@@ -5,18 +5,18 @@ import { expect } from 'chai';
 // see: https://github.com/mochajs/mocha/issues/1847
 const { describe, it } = global;
 
-import Header from '../Header';
+import Toolbar from '../Toolbar';
 
 
-describe('<Header />', () => {
+describe('<Toolbar />', () => {
 
-  it('renders a header element', () => {
+  it('renders the application\'s toolbar', () => {
     const wrapper = shallow(
-      <Header
+      <Toolbar
         template={''}
         onUpdateTemplate={() => {}}
-      />
-    );
-    expect(wrapper.find('header')).to.have.length(1);
+      />);
+
+    expect(wrapper.find('#toolbar')).to.have.length(1);
   });
 });

--- a/app/components/__tests__/templates/Slidedeck-test.js
+++ b/app/components/__tests__/templates/Slidedeck-test.js
@@ -16,8 +16,14 @@ describe('<Slidedeck />', () => {
     return (
       <PreviewChunk
         key={key++}
-        markdownIt={{}}
-        emojione={{}}
+        markdownIt={{
+          renderer: {
+            render: (content) => content
+          }
+        }}
+        emojione={{
+          toImage: (content) => content
+        }}
         chunk={[ { markup: content } ]}
         markdownItEnv={{}}
       />
@@ -45,7 +51,7 @@ describe('<Slidedeck />', () => {
       />
     );
 
-    expect(wrapper.find('section')).to.have.length(1);
+    expect(wrapper.find('Section')).to.have.length(1);
   });
 
   it('creates a new section after a separator', () => {
@@ -60,7 +66,7 @@ describe('<Slidedeck />', () => {
       />
     );
 
-    expect(wrapper.find('section')).to.have.length(2);
+    expect(wrapper.find('Section')).to.have.length(2);
   });
 
   it('configures transitions based on YAML front matter', () => {
@@ -75,9 +81,55 @@ describe('<Slidedeck />', () => {
       />
     );
 
-    const section = wrapper.find('section');
+    const section = wrapper.find('Section');
 
     expect(section).to.have.length(1);
-    expect(section.prop('data-transition')).to.equal('concave');
+    expect(section.prop('transition')).to.equal('concave');
+  });
+
+  it('supports vertical slides', () => {
+    const wrapper = shallow(
+      <Slidedeck
+        content={[
+          mockPreviewChunk('this is content'),
+          mockPreviewChunk('----'),
+          mockPreviewChunk('this is content')
+        ]}
+        data={{}}
+      />
+    );
+
+    expect(wrapper.find('Section')).to.have.length(1);
+    expect(wrapper.html()).to.contain(
+      '<section data-transition="zoom"><section data-transition="zoom">'
+    );
+  });
+
+  it('supports mixed horizontal and vertical slides', () => {
+    const wrapper = shallow(
+      <Slidedeck
+        content={[
+          mockPreviewChunk('Slide 1'),
+          mockPreviewChunk('---'),
+          mockPreviewChunk('Slide 2'),
+          mockPreviewChunk('----'),
+          mockPreviewChunk('Slide 2.1'),
+          mockPreviewChunk('---'),
+          mockPreviewChunk('Slide 3'),
+        ]}
+        data={{}}
+      />
+    );
+
+    expect(wrapper.find('Section')).to.have.length(3);
+    expect(wrapper.find('Section').at(0).html()).not.to.contain(
+      '</section></section>'
+    );
+    expect(wrapper.find('Section').at(1).html()).to.contain(
+      '</section></section>'
+    );
+    expect(wrapper.find('Section').at(2).html()).not.to.contain(
+      '</section></section>'
+    );
   });
 });

--- a/app/components/__tests__/templates/Slidedeck-test.js
+++ b/app/components/__tests__/templates/Slidedeck-test.js
@@ -62,4 +62,22 @@ describe('<Slidedeck />', () => {
 
     expect(wrapper.find('section')).to.have.length(2);
   });
+
+  it('configures transitions based on YAML front matter', () => {
+    const wrapper = shallow(
+      <Slidedeck
+        content={[
+          mockPreviewChunk('this is content')
+        ]}
+        data={{
+          transition: 'concave'
+        }}
+      />
+    );
+
+    const section = wrapper.find('section');
+
+    expect(section).to.have.length(1);
+    expect(section.prop('data-transition')).to.equal('concave');
+  });
 });

--- a/app/components/__tests__/templates/Slidedeck-test.js
+++ b/app/components/__tests__/templates/Slidedeck-test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+// see: https://github.com/mochajs/mocha/issues/1847
+const { describe, it } = global;
+
+import Slidedeck from '../../templates/Slidedeck';
+import { PreviewChunk } from '../../Preview';
+
+
+describe('<Slidedeck />', () => {
+
+  let key = 0;
+  const mockPreviewChunk = (content) => {
+    return (
+      <PreviewChunk
+        key={key++}
+        markdownIt={{}}
+        emojione={{}}
+        chunk={[ { markup: content } ]}
+        markdownItEnv={{}}
+      />
+    );
+  };
+
+  it('renders a Reveal slide deck', () => {
+    const wrapper = shallow(
+      <Slidedeck
+        content={['this is content']}
+        data={{}}
+      />
+    );
+
+    expect(wrapper.find('.reveal')).to.have.length(1);
+  });
+
+  it('converts a preview chunk into a section', () => {
+    const wrapper = shallow(
+      <Slidedeck
+        content={[
+          mockPreviewChunk('this is content')
+        ]}
+        data={{}}
+      />
+    );
+
+    expect(wrapper.find('section')).to.have.length(1);
+  });
+
+  it('creates a new section after a separator', () => {
+    const wrapper = shallow(
+      <Slidedeck
+        content={[
+          mockPreviewChunk('this is content'),
+          mockPreviewChunk('---'),
+          mockPreviewChunk('this is content')
+        ]}
+        data={{}}
+      />
+    );
+
+    expect(wrapper.find('section')).to.have.length(2);
+  });
+});

--- a/app/components/__tests__/templates/Slidedeck-test.js
+++ b/app/components/__tests__/templates/Slidedeck-test.js
@@ -101,7 +101,7 @@ describe('<Slidedeck />', () => {
 
     expect(wrapper.find('Section')).to.have.length(1);
     expect(wrapper.html()).to.contain(
-      '<section data-transition="zoom"><section data-transition="zoom">'
+      '<section data-transition="default"><section data-transition="default">'
     );
   });
 

--- a/app/components/loaders/Preview.jsx
+++ b/app/components/loaders/Preview.jsx
@@ -21,6 +21,7 @@ export default () => {
           require('markdown-it-abbr'),
           require('markdown-it-katex'),
         ],
+        markdownItContainer: require('markdown-it-container'),
         emojione: require('emojione')
       });
     });

--- a/app/components/loaders/Preview.jsx
+++ b/app/components/loaders/Preview.jsx
@@ -20,6 +20,7 @@ export default () => {
           require('markdown-it-ins'),
           require('markdown-it-abbr'),
           require('markdown-it-katex'),
+          require('markdown-it-classy'),
         ],
         markdownItContainer: require('markdown-it-container'),
         emojione: require('emojione')

--- a/app/components/templates/Base.jsx
+++ b/app/components/templates/Base.jsx
@@ -27,7 +27,7 @@ export default class Base extends Component {
     // Clean input data to avoid undefined or null object properties
     // This avoids preview crash when trying to access null.<property>
     for (const p in data) {
-      if (data.hasOwnProperty(p) && data[p] === null) {
+      if (data.hasOwnProperty(p) && null === data[p]) {
         delete cleaned[p];
       }
     }

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -47,7 +47,7 @@ export default class Slidedeck extends BaseTemplate {
     Reveal.initialize({
       embedded: true,
       fragments: false,
-      slideid: true,
+      slideNumber: true,
       progress: false,
       help: false,
       margin: 0,

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -56,6 +56,10 @@ export default class Slidedeck extends BaseTemplate {
     window.Reveal = Reveal;
   }
 
+  componentDidUpdate() {
+    Reveal.layout();
+  }
+
   render() {
     const data = this.getData();
     const slides = splitContentIntoSections(this.props.content, '---');

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -8,6 +8,7 @@ import '../../scss/reveal-theme.css';
 
 const { number, array, string } = React.PropTypes;
 
+// transforms a chunk set into subsets for Reveal sections
 const splitContentIntoSections = (content, separator) => {
   const sections = [];
 
@@ -38,7 +39,7 @@ export default class Slidedeck extends BaseTemplate {
 
   getDefaultData() {
     return {
-      transition: 'zoom',
+      transition: 'default',
     };
   }
 

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -32,7 +32,7 @@ export default class Slidedeck extends BaseTemplate {
         return;
       }
 
-      if ('---' === c.props.chunk[0].markup) {
+      if (c.props && '---' === c.props.chunk[0].markup) {
         if (itemsInSection.length > 0) {
           sections.push(itemsInSection);
           itemsInSection = [];
@@ -46,8 +46,8 @@ export default class Slidedeck extends BaseTemplate {
     return (
       <div className="reveal">
         <div className="slides">
-          {sections.map((section) =>
-            <section>
+          {sections.map((section, index) =>
+            <section key={`section-${index}`}>
               {section}
             </section>
           )}

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -21,6 +21,7 @@ export default class Slidedeck extends BaseTemplate {
       fragments: false,
       slideNumber: true,
       progress: false,
+      help: false,
     });
   }
 

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -46,7 +46,6 @@ export default class Slidedeck extends BaseTemplate {
   componentDidMount() {
     Reveal.initialize({
       embedded: true,
-      fragments: false,
       slideNumber: true,
       progress: false,
       help: false,

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -52,6 +52,8 @@ export default class Slidedeck extends BaseTemplate {
       help: false,
       margin: 0,
     });
+
+    window.Reveal = Reveal;
   }
 
   render() {

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -1,0 +1,58 @@
+/* eslint one-var: 0 */
+import React from 'react';
+import BaseTemplate from './Base';
+import Reveal from 'reveal.js';
+
+import '../../scss/reveal.css';
+import '../../scss/reveal-theme.css';
+
+/**
+ * Slidedeck template
+ */
+export default class Slidedeck extends BaseTemplate {
+
+  getDefaultData() {
+    return {};
+  }
+
+  componentDidMount() {
+    Reveal.initialize({
+      embedded: true,
+      fragments: false,
+      slideNumber: true,
+      progress: false,
+    });
+  }
+
+  render() {
+    const sections = [];
+    let itemsInSection = [];
+    this.props.content.forEach((c) => {
+      if ('preview-loader' === c.key) {
+        return;
+      }
+
+      if ('---' === c.props.chunk[0].markup) {
+        if (itemsInSection.length > 0) {
+          sections.push(itemsInSection);
+          itemsInSection = [];
+        }
+      } else {
+        itemsInSection.push(c);
+      }
+    });
+    sections.push(itemsInSection);
+
+    return (
+      <div className="reveal">
+        <div className="slides">
+          {sections.map((section) =>
+            <section>
+              {section}
+            </section>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -51,6 +51,9 @@ export default class Slidedeck extends BaseTemplate {
       progress: false,
       help: false,
       margin: 0,
+      keyboard: {
+        70: null,
+      },
     });
 
     window.Reveal = Reveal;

--- a/app/components/templates/Slidedeck.jsx
+++ b/app/components/templates/Slidedeck.jsx
@@ -12,7 +12,9 @@ import '../../scss/reveal-theme.css';
 export default class Slidedeck extends BaseTemplate {
 
   getDefaultData() {
-    return {};
+    return {
+      transition: 'zoom',
+    };
   }
 
   componentDidMount() {
@@ -22,10 +24,13 @@ export default class Slidedeck extends BaseTemplate {
       slideNumber: true,
       progress: false,
       help: false,
+      margin: 0,
     });
   }
 
   render() {
+    const data = this.getData();
+
     const sections = [];
     let itemsInSection = [];
     this.props.content.forEach((c) => {
@@ -48,7 +53,7 @@ export default class Slidedeck extends BaseTemplate {
       <div className="reveal">
         <div className="slides">
           {sections.map((section, index) =>
-            <section key={`section-${index}`}>
+            <section key={`section-${index}`} data-transition={data.transition}>
               {section}
             </section>
           )}

--- a/app/scss/_layout.scss
+++ b/app/scss/_layout.scss
@@ -10,7 +10,7 @@ $vertical-handler-width: 40px;
 /* -- mixins -- */
 @function header-height($breakpoint){
     @if $breakpoint == small {
-        @return $main-header-height * .5;
+        @return $main-header-height * 1.3;
     }
     @return $main-header-height;
 };

--- a/app/scss/_layout.scss
+++ b/app/scss/_layout.scss
@@ -9,131 +9,131 @@ $vertical-handler-width: 40px;
 
 /* -- mixins -- */
 @function header-height($breakpoint){
-    @if $breakpoint == small {
-        @return $main-header-height * 1.3;
-    }
-    @return $main-header-height;
+  @if $breakpoint == small {
+    @return $main-header-height * 1.3;
+  }
+  @return $main-header-height;
 };
 
 @function footer-height($breakpoint){
-    @if $breakpoint == small {
-        @return $main-footer-height * .9;
-    }
-    @return $main-footer-height;
+  @if $breakpoint == small {
+    @return $main-footer-height * .9;
+  }
+  @return $main-footer-height;
 };
 
 @function editor-height($breakpoint){
-    $header-footer-height: header-height($breakpoint) + footer-height($breakpoint);
+  $header-footer-height: header-height($breakpoint) + footer-height($breakpoint);
 
-    @return calc(100vh - #{$header-footer-height});
+  @return calc(100vh - #{$header-footer-height});
 };
 
 /* -- styles -- */
 .layout {
+  display: flex;
+  flex-direction: column;
+
+  header.main {
+    height: header-height(small);
+
+    @include breakpoint(medium) {
+      height: header-height(medium);
+    }
+  }
+
+  .loader {
+    height: editor-height(small);
+
+    @include breakpoint(medium) {
+      height: editor-height(medium);
+    }
+  }
+
+  .editor {
     display: flex;
-    flex-direction: column;
+    height: editor-height(small);
+    width: 100%;
 
-    header.main {
-        height: header-height(small);
-
-        @include breakpoint(medium) {
-            height: header-height(medium);
-        }
+    @include breakpoint(medium) {
+      height: editor-height(medium);
     }
 
-    .loader {
-        height: editor-height(small);
+    .markdown {
+      height: 100%;
+      width: 100%;
 
-        @include breakpoint(medium) {
-            height: editor-height(medium);
-        }
+      @include breakpoint(medium) {
+        flex: 1 1 calc(50% - #{$vertical-handler-width / 2});
+      }
     }
 
-    .editor {
-        display: flex;
-        height: editor-height(small);
-        width: 100%;
+    .vertical-handler {
+      width: $vertical-handler-width;
+    }
 
-        @include breakpoint(medium) {
-            height: editor-height(medium);
-        }
+    .preview {
+      @include show-for(medium);
+      height: 100%;
 
-        .markdown {
-            height: 100%;
-            width: 100%;
+      @include breakpoint(medium) {
+        flex: 1 1 calc(50% - #{$vertical-handler-width / 2});
+      }
+    }
 
-            @include breakpoint(medium) {
-                flex: 1 1 calc(50% - #{$vertical-handler-width / 2});
-            }
-        }
+    &.focus {
+      @include breakpoint(medium) {
+        .markdown {}
 
         .vertical-handler {
-            width: $vertical-handler-width;
+          width: $vertical-handler-width / 2;
+
+          .right {
+            display: none;
+          }
         }
 
         .preview {
-            @include show-for(medium);
-            height: 100%;
-
-            @include breakpoint(medium) {
-                flex: 1 1 calc(50% - #{$vertical-handler-width / 2});
-            }
+          display: none;
         }
-
-        &.focus {
-            @include breakpoint(medium) {
-                .markdown {}
-
-                .vertical-handler {
-                    width: $vertical-handler-width / 2;
-
-                    .right {
-                        display: none;
-                    }
-                }
-
-                .preview {
-                    display: none;
-                }
-            }
-        }
-
-        &.edit-preview {
-            @include breakpoint(medium) {
-                .markdown {
-                    display: block;
-                }
-
-                .preview {
-                    display: block;
-                }
-            }
-        }
-
-        &.reading {
-            @include breakpoint(medium) {
-                .markdown {
-                    display: none;
-                }
-
-                .vertical-handler {
-                    width: $vertical-handler-width / 2;
-
-                    .left {
-                        display: none;
-                    }
-                }
-
-                .preview {}
-            }
-        }
+      }
     }
 
-    footer.main {
-        height: footer-height(small);
-
-        @include breakpoint(medium) {
-            height: footer-height(medium);
+    &.edit-preview {
+      @include breakpoint(medium) {
+        .markdown {
+          display: block;
         }
+
+        .preview {
+          display: block;
+        }
+      }
     }
+
+    &.reading {
+      @include breakpoint(medium) {
+        .markdown {
+          display: none;
+        }
+
+        .vertical-handler {
+          width: $vertical-handler-width / 2;
+
+          .left {
+            display: none;
+          }
+        }
+
+        .preview {}
+      }
+    }
+  }
+
+  footer.main {
+    height: footer-height(small);
+
+    @include breakpoint(medium) {
+      height: footer-height(medium);
+    }
+  }
 }

--- a/app/scss/_layout.scss
+++ b/app/scss/_layout.scss
@@ -28,7 +28,37 @@ $vertical-handler-width: 40px;
   @return calc(100vh - #{$header-footer-height});
 };
 
+@mixin fullscreen {
+  height: 100vh;
+  width: 100vw;
+  background-color: $alabaster;
+}
+
 /* -- styles -- */
+:-webkit-full-screen {
+  @include fullscreen;
+}
+
+:-webkit-full-screen {
+  @include fullscreen;
+}
+
+:-moz-full-screen {
+  @include fullscreen;
+}
+
+:-ms-fullscreen {
+  @include fullscreen;
+}
+
+:full-screen {
+  @include fullscreen;
+}
+
+:fullscreen {
+  @include fullscreen;
+}
+
 .layout {
   display: flex;
   flex-direction: column;
@@ -78,6 +108,8 @@ $vertical-handler-width: 40px;
       @include breakpoint(medium) {
         flex: 1 1 calc(50% - #{$vertical-handler-width / 2});
       }
+
+
     }
 
     &.focus {

--- a/app/scss/_layout.scss
+++ b/app/scss/_layout.scss
@@ -32,6 +32,17 @@ $vertical-handler-width: 40px;
   height: 100vh;
   width: 100vw;
   background-color: $alabaster;
+
+  .reveal {
+
+    .controls {
+      bottom: 10px !important;
+    }
+
+    .slide-number {
+      bottom: 8px !important;
+    }
+  }
 }
 
 /* -- styles -- */

--- a/app/scss/components/_footer.scss
+++ b/app/scss/components/_footer.scss
@@ -13,11 +13,14 @@ footer.main {
         float: left;
     }
 
-    .version {
+    .version,
+    .help {
         float: right;
         margin-top: 0.1rem;
+        margin-left: 0.1rem;
+        margin-right: 0.1rem;
 
-        .git-ref {
+        &> span {
             padding: 0.4rem 0.5rem 0.3rem;
             border-radius: $global-radius;
             background-color: darken($td-blue, 10%);

--- a/app/scss/components/_header.scss
+++ b/app/scss/components/_header.scss
@@ -3,14 +3,19 @@
  */
 
 header.main {
-    background-color: $primary-color;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
+  background-color: $primary-color;
 
-    h1 {
-        margin-left: 1rem;
-        color: $white;
+  h1 {
+    flex-grow: 1;
+    padding: 0 1rem;
+    color: $white;
 
-        small {
-            color: darken($primary-color, 10%);
-        }
+    small {
+      color: darken($primary-color, 10%);
     }
+  }
 }

--- a/app/scss/components/_preview.scss
+++ b/app/scss/components/_preview.scss
@@ -102,5 +102,19 @@
                 margin-top: 1.6rem;
             }
         }
+
+        .reveal {
+            p {
+                text-align: inherit!important;
+            }
+
+            .controls {
+                bottom: 40px;
+            }
+
+            .slide-number {
+                bottom: 43px;
+            }
+        }
     }
 }

--- a/app/scss/components/_preview.scss
+++ b/app/scss/components/_preview.scss
@@ -106,6 +106,18 @@
         .reveal {
             p {
                 text-align: inherit!important;
+
+                &.justify {
+                    text-align: justify!important;
+                }
+
+                &.left {
+                    text-align: left!important;
+                }
+
+                &.right {
+                    text-align: right!important;
+                }
             }
 
             img {

--- a/app/scss/components/_preview.scss
+++ b/app/scss/components/_preview.scss
@@ -108,6 +108,10 @@
                 text-align: inherit!important;
             }
 
+            img {
+                display: inline-block;
+            }
+
             .katex {
                 font-size: inherit;
             }

--- a/app/scss/components/_preview.scss
+++ b/app/scss/components/_preview.scss
@@ -108,6 +108,10 @@
                 text-align: inherit!important;
             }
 
+            .katex {
+                font-size: inherit;
+            }
+
             .controls {
                 bottom: 40px;
             }

--- a/app/scss/components/_template_form.scss
+++ b/app/scss/components/_template_form.scss
@@ -3,13 +3,11 @@
  */
 
 #templateForm {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
+  display: inline-block;
 
-    select {
-        margin-right: 1rem;
+  select {
+    width: auto;
 
-        option {}
-    }
+    option {}
+  }
 }

--- a/app/scss/components/_template_form.scss
+++ b/app/scss/components/_template_form.scss
@@ -6,7 +6,7 @@
   vertical-align: top;
 
   select {
-    width: auto;
+    min-width: 8rem;
 
     option {}
   }

--- a/app/scss/components/_template_form.scss
+++ b/app/scss/components/_template_form.scss
@@ -3,7 +3,7 @@
  */
 
 #templateForm {
-  display: inline-block;
+  vertical-align: top;
 
   select {
     width: auto;

--- a/app/scss/components/_toolbar.scss
+++ b/app/scss/components/_toolbar.scss
@@ -18,4 +18,12 @@
       padding-left: 0.5rem;
     }
   }
+
+  .actions {
+    @include button-group('.action');
+
+    .action {
+      @include button($background: darken($primary-color, 10%));
+    }
+  }
 }

--- a/app/scss/components/_toolbar.scss
+++ b/app/scss/components/_toolbar.scss
@@ -1,0 +1,21 @@
+/*
+ * Toolbar component
+ */
+
+#toolbar {
+  text-align: right;
+  padding: 0 1rem;
+
+  @include breakpoint(medium) {
+    padding: 1rem;
+  }
+
+  & > * {
+    display: inline-block;
+    padding-right: 0.5rem;
+
+    &:not(:first-child) {
+      padding-left: 0.5rem;
+    }
+  }
+}

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -11,6 +11,8 @@
 @include foundation-table;
 @include foundation-callout;
 @include foundation-close-button;
+@include foundation-button;
+@include foundation-button-group;
 
 /* -- FontAwesome -- */
 $fa-font-path: '~font-awesome/fonts';

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -24,6 +24,7 @@ $fa-font-path: '~font-awesome/fonts';
 
 // Components
 @import 'components/header';
+@import 'components/toolbar';
 @import 'components/template_form';
 @import 'components/editor';
 @import 'components/markdown';

--- a/app/scss/reveal-theme.css
+++ b/app/scss/reveal-theme.css
@@ -129,8 +129,7 @@
   font-size: 0.55em;
   font-family: monospace;
   line-height: 1.2em;
-  word-wrap: break-word;
-  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
+  word-wrap: break-word; }
 
 .reveal code {
   font-family: monospace; }
@@ -208,7 +207,7 @@
 .reveal section img {
   margin: 15px 0px;
   background: rgba(255, 255, 255, 0.12);
-  border: 4px solid #222;
+  border: 2px solid #1ABC9C;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); }
 
 .reveal section img.plain {

--- a/app/scss/reveal-theme.css
+++ b/app/scss/reveal-theme.css
@@ -106,12 +106,11 @@
 .reveal blockquote {
   display: block;
   position: relative;
-  width: 70%;
   margin: 20px auto;
   padding: 5px;
   font-style: italic;
   background: rgba(255, 255, 255, 0.05);
-  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2); }
+  }
 
 .reveal blockquote p:first-child,
 .reveal blockquote p:last-child {

--- a/app/scss/reveal-theme.css
+++ b/app/scss/reveal-theme.css
@@ -265,3 +265,16 @@
   -webkit-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
   -moz-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
   transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }
+
+/**
+ * Monod customization
+ */
+.reveal .no-border img {
+  border: 0 !important;
+  box-shadow: none !important;
+  background: none !important;
+}
+
+.reveal .no-bullets li {
+  list-style-type: none;
+}

--- a/app/scss/reveal-theme.css
+++ b/app/scss/reveal-theme.css
@@ -1,0 +1,269 @@
+/*********************************************
+ * GLOBAL STYLES
+ *********************************************/
+.reveal {
+  font-family: "Source Sans Pro", Helvetica, sans-serif;
+  font-size: 38px;
+  font-weight: normal;
+  color: #222; }
+
+.reveal .slides > section,
+.reveal .slides > section > section {
+  line-height: 1.3;
+  font-weight: inherit; }
+
+/*********************************************
+ * HEADERS
+ *********************************************/
+.reveal h1,
+.reveal h2,
+.reveal h3,
+.reveal h4,
+.reveal h5,
+.reveal h6 {
+  margin: 0 0 20px 0;
+  color: #222;
+  font-family: "Source Sans Pro", Helvetica, sans-serif;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: normal;
+  text-transform: uppercase;
+  text-shadow: none;
+  word-wrap: break-word; }
+
+.reveal h1 {
+  font-size: 2.5em; }
+
+.reveal h2 {
+  font-size: 1.6em; }
+
+.reveal h3 {
+  font-size: 1.3em; }
+
+.reveal h4 {
+  font-size: 1em; }
+
+.reveal h1 {
+  text-shadow: none; }
+
+/*********************************************
+ * OTHER
+ *********************************************/
+.reveal p {
+  margin: 20px 0;
+  line-height: 1.3; }
+
+/* Ensure certain elements are never larger than the slide itself */
+.reveal img,
+.reveal video,
+.reveal iframe {
+  max-width: 95%;
+  max-height: 95%; }
+
+.reveal strong,
+.reveal b {
+  font-weight: bold; }
+
+.reveal em {
+  font-style: italic; }
+
+.reveal ol,
+.reveal dl,
+.reveal ul {
+  display: inline-block;
+  text-align: left;
+  margin: 0 0 0 1em; }
+
+.reveal ol {
+  list-style-type: decimal; }
+
+.reveal ul {
+  list-style-type: disc; }
+
+.reveal ul ul {
+  list-style-type: square; }
+
+.reveal ul ul ul {
+  list-style-type: circle; }
+
+.reveal ul ul,
+.reveal ul ol,
+.reveal ol ol,
+.reveal ol ul {
+  display: block;
+  margin-left: 40px; }
+
+.reveal dt {
+  font-weight: bold; }
+
+.reveal dd {
+  margin-left: 40px; }
+
+.reveal q,
+.reveal blockquote {
+  quotes: none; }
+
+.reveal blockquote {
+  display: block;
+  position: relative;
+  width: 70%;
+  margin: 20px auto;
+  padding: 5px;
+  font-style: italic;
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2); }
+
+.reveal blockquote p:first-child,
+.reveal blockquote p:last-child {
+  display: inline-block; }
+
+.reveal q {
+  font-style: italic; }
+
+.reveal pre {
+  display: block;
+  position: relative;
+  width: 90%;
+  margin: 20px auto;
+  text-align: left;
+  font-size: 0.55em;
+  font-family: monospace;
+  line-height: 1.2em;
+  word-wrap: break-word;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
+
+.reveal code {
+  font-family: monospace; }
+
+.reveal pre code {
+  display: block;
+  padding: 5px;
+  overflow: auto;
+  max-height: 400px;
+  word-wrap: normal; }
+
+.reveal table {
+  margin: auto;
+  border-collapse: collapse;
+  border-spacing: 0; }
+
+.reveal table th {
+  font-weight: bold; }
+
+.reveal table th,
+.reveal table td {
+  text-align: left;
+  padding: 0.2em 0.5em 0.2em 0.5em;
+  border-bottom: 1px solid; }
+
+.reveal table th[align="center"],
+.reveal table td[align="center"] {
+  text-align: center; }
+
+.reveal table th[align="right"],
+.reveal table td[align="right"] {
+  text-align: right; }
+
+.reveal table tbody tr:last-child th,
+.reveal table tbody tr:last-child td {
+  border-bottom: none; }
+
+.reveal sup {
+  vertical-align: super; }
+
+.reveal sub {
+  vertical-align: sub; }
+
+.reveal small {
+  display: inline-block;
+  font-size: 0.6em;
+  line-height: 1.2em;
+  vertical-align: top; }
+
+.reveal small * {
+  vertical-align: top; }
+
+/*********************************************
+ * LINKS
+ *********************************************/
+.reveal a {
+  color: #1abc9c;
+  text-decoration: none;
+  -webkit-transition: color .15s ease;
+  -moz-transition: color .15s ease;
+  transition: color .15s ease; }
+
+.reveal a:hover {
+  color: #2e354f;
+  text-shadow: none;
+  border: none; }
+
+.reveal .roll span:after {
+  color: #fff;
+  background: #1a53a1; }
+
+/*********************************************
+ * IMAGES
+ *********************************************/
+.reveal section img {
+  margin: 15px 0px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 4px solid #222;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); }
+
+.reveal section img.plain {
+  border: 0;
+  box-shadow: none; }
+
+.reveal a img {
+  -webkit-transition: all .15s linear;
+  -moz-transition: all .15s linear;
+  transition: all .15s linear; }
+
+.reveal a:hover img {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: #1abc9c;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
+
+/*********************************************
+ * NAVIGATION CONTROLS
+ *********************************************/
+.reveal .controls .navigate-left,
+.reveal .controls .navigate-left.enabled {
+  border-right-color: #1abc9c; }
+
+.reveal .controls .navigate-right,
+.reveal .controls .navigate-right.enabled {
+  border-left-color: #1abc9c; }
+
+.reveal .controls .navigate-up,
+.reveal .controls .navigate-up.enabled {
+  border-bottom-color: #1abc9c; }
+
+.reveal .controls .navigate-down,
+.reveal .controls .navigate-down.enabled {
+  border-top-color: #1abc9c; }
+
+.reveal .controls .navigate-left.enabled:hover {
+  border-right-color: #2e354f; }
+
+.reveal .controls .navigate-right.enabled:hover {
+  border-left-color: #2e354f; }
+
+.reveal .controls .navigate-up.enabled:hover {
+  border-bottom-color: #2e354f; }
+
+.reveal .controls .navigate-down.enabled:hover {
+  border-top-color: #2e354f; }
+
+/*********************************************
+ * PROGRESS BAR
+ *********************************************/
+.reveal .progress {
+  background: rgba(0, 0, 0, 0.2); }
+
+.reveal .progress span {
+  background: #1abc9c;
+  -webkit-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+  -moz-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+  transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }

--- a/app/scss/reveal.css
+++ b/app/scss/reveal.css
@@ -1,0 +1,1332 @@
+/*!
+ * reveal.js
+ * http://lab.hakim.se/reveal-js
+ * MIT licensed
+ *
+ * Copyright (C) 2016 Hakim El Hattab, http://hakim.se
+ */
+/*********************************************
+ * RESET STYLES
+ *********************************************/
+
+/*
+ * Updated by William:
+ *   - removed html, body below
+ *   - removed global style
+ */
+
+.reveal div, .reveal span, .reveal applet, .reveal object, .reveal iframe,
+.reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6, .reveal p, .reveal blockquote, .reveal pre,
+.reveal a, .reveal abbr, .reveal acronym, .reveal address, .reveal big, .reveal cite, .reveal code,
+.reveal del, .reveal dfn, .reveal em, .reveal img, .reveal ins, .reveal kbd, .reveal q, .reveal s, .reveal samp,
+.reveal small, .reveal strike, .reveal strong, .reveal sub, .reveal sup, .reveal tt, .reveal var,
+.reveal b, .reveal u, .reveal center,
+.reveal dl, .reveal dt, .reveal dd, .reveal ol, .reveal ul, .reveal li,
+.reveal fieldset, .reveal form, .reveal label, .reveal legend,
+.reveal table, .reveal caption, .reveal tbody, .reveal tfoot, .reveal thead, .reveal tr, .reveal th, .reveal td,
+.reveal article, .reveal aside, .reveal canvas, .reveal details, .reveal embed,
+.reveal figure, .reveal figcaption, .reveal footer, .reveal header, .reveal hgroup,
+.reveal menu, .reveal nav, .reveal output, .reveal ruby, .reveal section, .reveal summary,
+.reveal time, .reveal mark, .reveal audio, .reveal video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline; }
+
+.reveal article, .reveal aside, .reveal details, .reveal figcaption, .reveal figure,
+.reveal footer, .reveal header, .reveal hgroup, .reveal menu, .reveal nav, .reveal section {
+  display: block; }
+
+/*********************************************
+ * GLOBAL STYLES
+ *********************************************/
+html,
+body {
+  width: 100%;
+  height: 100%;
+  overflow: hidden; }
+
+html:-webkit-full-screen-ancestor {
+  background-color: inherit; }
+
+html:-moz-full-screen-ancestor {
+  background-color: inherit; }
+
+/*********************************************
+ * VIEW FRAGMENTS
+ *********************************************/
+.reveal .slides section .fragment {
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: all .2s ease;
+          transition: all .2s ease; }
+  .reveal .slides section .fragment.visible {
+    opacity: 1;
+    visibility: visible; }
+
+.reveal .slides section .fragment.grow {
+  opacity: 1;
+  visibility: visible; }
+  .reveal .slides section .fragment.grow.visible {
+    -webkit-transform: scale(1.3);
+            transform: scale(1.3); }
+
+.reveal .slides section .fragment.shrink {
+  opacity: 1;
+  visibility: visible; }
+  .reveal .slides section .fragment.shrink.visible {
+    -webkit-transform: scale(0.7);
+            transform: scale(0.7); }
+
+.reveal .slides section .fragment.zoom-in {
+  -webkit-transform: scale(0.1);
+          transform: scale(0.1); }
+  .reveal .slides section .fragment.zoom-in.visible {
+    -webkit-transform: none;
+            transform: none; }
+
+.reveal .slides section .fragment.fade-out {
+  opacity: 1;
+  visibility: visible; }
+  .reveal .slides section .fragment.fade-out.visible {
+    opacity: 0;
+    visibility: hidden; }
+
+.reveal .slides section .fragment.semi-fade-out {
+  opacity: 1;
+  visibility: visible; }
+  .reveal .slides section .fragment.semi-fade-out.visible {
+    opacity: 0.5;
+    visibility: visible; }
+
+.reveal .slides section .fragment.strike {
+  opacity: 1;
+  visibility: visible; }
+  .reveal .slides section .fragment.strike.visible {
+    text-decoration: line-through; }
+
+.reveal .slides section .fragment.fade-up {
+  -webkit-transform: translate(0, 20%);
+          transform: translate(0, 20%); }
+  .reveal .slides section .fragment.fade-up.visible {
+    -webkit-transform: translate(0, 0);
+            transform: translate(0, 0); }
+
+.reveal .slides section .fragment.fade-down {
+  -webkit-transform: translate(0, -20%);
+          transform: translate(0, -20%); }
+  .reveal .slides section .fragment.fade-down.visible {
+    -webkit-transform: translate(0, 0);
+            transform: translate(0, 0); }
+
+.reveal .slides section .fragment.fade-right {
+  -webkit-transform: translate(-20%, 0);
+          transform: translate(-20%, 0); }
+  .reveal .slides section .fragment.fade-right.visible {
+    -webkit-transform: translate(0, 0);
+            transform: translate(0, 0); }
+
+.reveal .slides section .fragment.fade-left {
+  -webkit-transform: translate(20%, 0);
+          transform: translate(20%, 0); }
+  .reveal .slides section .fragment.fade-left.visible {
+    -webkit-transform: translate(0, 0);
+            transform: translate(0, 0); }
+
+.reveal .slides section .fragment.current-visible {
+  opacity: 0;
+  visibility: hidden; }
+  .reveal .slides section .fragment.current-visible.current-fragment {
+    opacity: 1;
+    visibility: visible; }
+
+.reveal .slides section .fragment.highlight-red,
+.reveal .slides section .fragment.highlight-current-red,
+.reveal .slides section .fragment.highlight-green,
+.reveal .slides section .fragment.highlight-current-green,
+.reveal .slides section .fragment.highlight-blue,
+.reveal .slides section .fragment.highlight-current-blue {
+  opacity: 1;
+  visibility: visible; }
+
+.reveal .slides section .fragment.highlight-red.visible {
+  color: #ff2c2d; }
+
+.reveal .slides section .fragment.highlight-green.visible {
+  color: #17ff2e; }
+
+.reveal .slides section .fragment.highlight-blue.visible {
+  color: #1b91ff; }
+
+.reveal .slides section .fragment.highlight-current-red.current-fragment {
+  color: #ff2c2d; }
+
+.reveal .slides section .fragment.highlight-current-green.current-fragment {
+  color: #17ff2e; }
+
+.reveal .slides section .fragment.highlight-current-blue.current-fragment {
+  color: #1b91ff; }
+
+/*********************************************
+ * DEFAULT ELEMENT STYLES
+ *********************************************/
+/* Fixes issue in Chrome where italic fonts did not appear when printing to PDF */
+.reveal:after {
+  content: '';
+  font-style: italic; }
+
+.reveal iframe {
+  z-index: 1; }
+
+/** Prevents layering issues in certain browser/transition combinations */
+.reveal a {
+  position: relative; }
+
+.reveal .stretch {
+  max-width: none;
+  max-height: none; }
+
+.reveal pre.stretch code {
+  height: 100%;
+  max-height: 100%;
+  box-sizing: border-box; }
+
+/*********************************************
+ * CONTROLS
+ *********************************************/
+.reveal .controls {
+  display: none;
+  position: fixed;
+  width: 110px;
+  height: 110px;
+  z-index: 30;
+  right: 10px;
+  bottom: 10px;
+  -webkit-user-select: none; }
+
+.reveal .controls button {
+  padding: 0;
+  position: absolute;
+  opacity: 0.05;
+  width: 0;
+  height: 0;
+  background-color: transparent;
+  border: 12px solid transparent;
+  -webkit-transform: scale(0.9999);
+          transform: scale(0.9999);
+  -webkit-transition: all 0.2s ease;
+          transition: all 0.2s ease;
+  -webkit-appearance: none;
+  -webkit-tap-highlight-color: transparent; }
+
+.reveal .controls .enabled {
+  opacity: 0.7;
+  cursor: pointer; }
+
+.reveal .controls .enabled:active {
+  margin-top: 1px; }
+
+.reveal .controls .navigate-left {
+  top: 42px;
+  border-right-width: 22px;
+  border-right-color: #000; }
+
+.reveal .controls .navigate-left.fragmented {
+  opacity: 0.3; }
+
+.reveal .controls .navigate-right {
+  left: 74px;
+  top: 42px;
+  border-left-width: 22px;
+  border-left-color: #000; }
+
+.reveal .controls .navigate-right.fragmented {
+  opacity: 0.3; }
+
+.reveal .controls .navigate-up {
+  left: 42px;
+  border-bottom-width: 22px;
+  border-bottom-color: #000; }
+
+.reveal .controls .navigate-up.fragmented {
+  opacity: 0.3; }
+
+.reveal .controls .navigate-down {
+  left: 42px;
+  top: 74px;
+  border-top-width: 22px;
+  border-top-color: #000; }
+
+.reveal .controls .navigate-down.fragmented {
+  opacity: 0.3; }
+
+/*********************************************
+ * PROGRESS BAR
+ *********************************************/
+.reveal .progress {
+  position: fixed;
+  display: none;
+  height: 3px;
+  width: 100%;
+  bottom: 0;
+  left: 0;
+  z-index: 10;
+  background-color: rgba(0, 0, 0, 0.2); }
+
+.reveal .progress:after {
+  content: '';
+  display: block;
+  position: absolute;
+  height: 20px;
+  width: 100%;
+  top: -20px; }
+
+.reveal .progress span {
+  display: block;
+  height: 100%;
+  width: 0px;
+  background-color: #000;
+  -webkit-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+          transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }
+
+/*********************************************
+ * SLIDE NUMBER
+ *********************************************/
+.reveal .slide-number {
+  position: fixed;
+  display: block;
+  right: 8px;
+  bottom: 8px;
+  z-index: 31;
+  font-family: Helvetica, sans-serif;
+  font-size: 12px;
+  line-height: 1;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.4);
+  padding: 5px; }
+
+.reveal .slide-number-delimiter {
+  margin: 0 3px; }
+
+/*********************************************
+ * SLIDES
+ *********************************************/
+.reveal {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  -ms-touch-action: none;
+      touch-action: none; }
+
+.reveal .slides {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  overflow: visible;
+  z-index: 1;
+  text-align: center;
+  -webkit-perspective: 600px;
+          perspective: 600px;
+  -webkit-perspective-origin: 50% 40%;
+          perspective-origin: 50% 40%; }
+
+.reveal .slides > section {
+  -ms-perspective: 600px; }
+
+.reveal .slides > section,
+.reveal .slides > section > section {
+  display: none;
+  position: absolute;
+  width: 100%;
+  padding: 20px 0px;
+  z-index: 10;
+  -webkit-transform-style: preserve-3d;
+          transform-style: preserve-3d;
+  -webkit-transition: -webkit-transform-origin 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), -webkit-transform 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), visibility 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), opacity 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+          transition: transform-origin 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), transform 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), visibility 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), opacity 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }
+
+/* Global transition speed settings */
+.reveal[data-transition-speed="fast"] .slides section {
+  -webkit-transition-duration: 400ms;
+          transition-duration: 400ms; }
+
+.reveal[data-transition-speed="slow"] .slides section {
+  -webkit-transition-duration: 1200ms;
+          transition-duration: 1200ms; }
+
+/* Slide-specific transition speed overrides */
+.reveal .slides section[data-transition-speed="fast"] {
+  -webkit-transition-duration: 400ms;
+          transition-duration: 400ms; }
+
+.reveal .slides section[data-transition-speed="slow"] {
+  -webkit-transition-duration: 1200ms;
+          transition-duration: 1200ms; }
+
+.reveal .slides > section.stack {
+  padding-top: 0;
+  padding-bottom: 0; }
+
+.reveal .slides > section.present,
+.reveal .slides > section > section.present {
+  display: block;
+  z-index: 11;
+  opacity: 1; }
+
+.reveal.center,
+.reveal.center .slides,
+.reveal.center .slides section {
+  min-height: 0 !important; }
+
+/* Don't allow interaction with invisible slides */
+.reveal .slides > section.future,
+.reveal .slides > section > section.future,
+.reveal .slides > section.past,
+.reveal .slides > section > section.past {
+  pointer-events: none; }
+
+.reveal.overview .slides > section,
+.reveal.overview .slides > section > section {
+  pointer-events: auto; }
+
+.reveal .slides > section.past,
+.reveal .slides > section.future,
+.reveal .slides > section > section.past,
+.reveal .slides > section > section.future {
+  opacity: 0; }
+
+/*********************************************
+ * Mixins for readability of transitions
+ *********************************************/
+/*********************************************
+ * SLIDE TRANSITION
+ * Aliased 'linear' for backwards compatibility
+ *********************************************/
+.reveal.slide section {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+
+.reveal .slides > section[data-transition=slide].past,
+.reveal .slides > section[data-transition~=slide-out].past,
+.reveal.slide .slides > section:not([data-transition]).past {
+  -webkit-transform: translate(-150%, 0);
+          transform: translate(-150%, 0); }
+
+.reveal .slides > section[data-transition=slide].future,
+.reveal .slides > section[data-transition~=slide-in].future,
+.reveal.slide .slides > section:not([data-transition]).future {
+  -webkit-transform: translate(150%, 0);
+          transform: translate(150%, 0); }
+
+.reveal .slides > section > section[data-transition=slide].past,
+.reveal .slides > section > section[data-transition~=slide-out].past,
+.reveal.slide .slides > section > section:not([data-transition]).past {
+  -webkit-transform: translate(0, -150%);
+          transform: translate(0, -150%); }
+
+.reveal .slides > section > section[data-transition=slide].future,
+.reveal .slides > section > section[data-transition~=slide-in].future,
+.reveal.slide .slides > section > section:not([data-transition]).future {
+  -webkit-transform: translate(0, 150%);
+          transform: translate(0, 150%); }
+
+.reveal.linear section {
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+
+.reveal .slides > section[data-transition=linear].past,
+.reveal .slides > section[data-transition~=linear-out].past,
+.reveal.linear .slides > section:not([data-transition]).past {
+  -webkit-transform: translate(-150%, 0);
+          transform: translate(-150%, 0); }
+
+.reveal .slides > section[data-transition=linear].future,
+.reveal .slides > section[data-transition~=linear-in].future,
+.reveal.linear .slides > section:not([data-transition]).future {
+  -webkit-transform: translate(150%, 0);
+          transform: translate(150%, 0); }
+
+.reveal .slides > section > section[data-transition=linear].past,
+.reveal .slides > section > section[data-transition~=linear-out].past,
+.reveal.linear .slides > section > section:not([data-transition]).past {
+  -webkit-transform: translate(0, -150%);
+          transform: translate(0, -150%); }
+
+.reveal .slides > section > section[data-transition=linear].future,
+.reveal .slides > section > section[data-transition~=linear-in].future,
+.reveal.linear .slides > section > section:not([data-transition]).future {
+  -webkit-transform: translate(0, 150%);
+          transform: translate(0, 150%); }
+
+/*********************************************
+ * CONVEX TRANSITION
+ * Aliased 'default' for backwards compatibility
+ *********************************************/
+.reveal .slides > section[data-transition=default].past,
+.reveal .slides > section[data-transition~=default-out].past,
+.reveal.default .slides > section:not([data-transition]).past {
+  -webkit-transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0);
+          transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
+
+.reveal .slides > section[data-transition=default].future,
+.reveal .slides > section[data-transition~=default-in].future,
+.reveal.default .slides > section:not([data-transition]).future {
+  -webkit-transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0);
+          transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
+
+.reveal .slides > section > section[data-transition=default].past,
+.reveal .slides > section > section[data-transition~=default-out].past,
+.reveal.default .slides > section > section:not([data-transition]).past {
+  -webkit-transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0);
+          transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0); }
+
+.reveal .slides > section > section[data-transition=default].future,
+.reveal .slides > section > section[data-transition~=default-in].future,
+.reveal.default .slides > section > section:not([data-transition]).future {
+  -webkit-transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0);
+          transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0); }
+
+.reveal .slides > section[data-transition=convex].past,
+.reveal .slides > section[data-transition~=convex-out].past,
+.reveal.convex .slides > section:not([data-transition]).past {
+  -webkit-transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0);
+          transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
+
+.reveal .slides > section[data-transition=convex].future,
+.reveal .slides > section[data-transition~=convex-in].future,
+.reveal.convex .slides > section:not([data-transition]).future {
+  -webkit-transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0);
+          transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
+
+.reveal .slides > section > section[data-transition=convex].past,
+.reveal .slides > section > section[data-transition~=convex-out].past,
+.reveal.convex .slides > section > section:not([data-transition]).past {
+  -webkit-transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0);
+          transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0); }
+
+.reveal .slides > section > section[data-transition=convex].future,
+.reveal .slides > section > section[data-transition~=convex-in].future,
+.reveal.convex .slides > section > section:not([data-transition]).future {
+  -webkit-transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0);
+          transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0); }
+
+/*********************************************
+ * CONCAVE TRANSITION
+ *********************************************/
+.reveal .slides > section[data-transition=concave].past,
+.reveal .slides > section[data-transition~=concave-out].past,
+.reveal.concave .slides > section:not([data-transition]).past {
+  -webkit-transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0);
+          transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0); }
+
+.reveal .slides > section[data-transition=concave].future,
+.reveal .slides > section[data-transition~=concave-in].future,
+.reveal.concave .slides > section:not([data-transition]).future {
+  -webkit-transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0);
+          transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0); }
+
+.reveal .slides > section > section[data-transition=concave].past,
+.reveal .slides > section > section[data-transition~=concave-out].past,
+.reveal.concave .slides > section > section:not([data-transition]).past {
+  -webkit-transform: translate3d(0, -80%, 0) rotateX(-70deg) translate3d(0, -80%, 0);
+          transform: translate3d(0, -80%, 0) rotateX(-70deg) translate3d(0, -80%, 0); }
+
+.reveal .slides > section > section[data-transition=concave].future,
+.reveal .slides > section > section[data-transition~=concave-in].future,
+.reveal.concave .slides > section > section:not([data-transition]).future {
+  -webkit-transform: translate3d(0, 80%, 0) rotateX(70deg) translate3d(0, 80%, 0);
+          transform: translate3d(0, 80%, 0) rotateX(70deg) translate3d(0, 80%, 0); }
+
+/*********************************************
+ * ZOOM TRANSITION
+ *********************************************/
+.reveal .slides section[data-transition=zoom],
+.reveal.zoom .slides section:not([data-transition]) {
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease; }
+
+.reveal .slides > section[data-transition=zoom].past,
+.reveal .slides > section[data-transition~=zoom-out].past,
+.reveal.zoom .slides > section:not([data-transition]).past {
+  visibility: hidden;
+  -webkit-transform: scale(16);
+          transform: scale(16); }
+
+.reveal .slides > section[data-transition=zoom].future,
+.reveal .slides > section[data-transition~=zoom-in].future,
+.reveal.zoom .slides > section:not([data-transition]).future {
+  visibility: hidden;
+  -webkit-transform: scale(0.2);
+          transform: scale(0.2); }
+
+.reveal .slides > section > section[data-transition=zoom].past,
+.reveal .slides > section > section[data-transition~=zoom-out].past,
+.reveal.zoom .slides > section > section:not([data-transition]).past {
+  -webkit-transform: translate(0, -150%);
+          transform: translate(0, -150%); }
+
+.reveal .slides > section > section[data-transition=zoom].future,
+.reveal .slides > section > section[data-transition~=zoom-in].future,
+.reveal.zoom .slides > section > section:not([data-transition]).future {
+  -webkit-transform: translate(0, 150%);
+          transform: translate(0, 150%); }
+
+/*********************************************
+ * CUBE TRANSITION
+ *********************************************/
+.reveal.cube .slides {
+  -webkit-perspective: 1300px;
+          perspective: 1300px; }
+
+.reveal.cube .slides section {
+  padding: 30px;
+  min-height: 700px;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
+  box-sizing: border-box; }
+
+.reveal.center.cube .slides section {
+  min-height: 0; }
+
+.reveal.cube .slides section:not(.stack):before {
+  content: '';
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  -webkit-transform: translateZ(-20px);
+          transform: translateZ(-20px); }
+
+.reveal.cube .slides section:not(.stack):after {
+  content: '';
+  position: absolute;
+  display: block;
+  width: 90%;
+  height: 30px;
+  left: 5%;
+  bottom: 0;
+  background: none;
+  z-index: 1;
+  border-radius: 4px;
+  box-shadow: 0px 95px 25px rgba(0, 0, 0, 0.2);
+  -webkit-transform: translateZ(-90px) rotateX(65deg);
+          transform: translateZ(-90px) rotateX(65deg); }
+
+.reveal.cube .slides > section.stack {
+  padding: 0;
+  background: none; }
+
+.reveal.cube .slides > section.past {
+  -webkit-transform-origin: 100% 0%;
+          transform-origin: 100% 0%;
+  -webkit-transform: translate3d(-100%, 0, 0) rotateY(-90deg);
+          transform: translate3d(-100%, 0, 0) rotateY(-90deg); }
+
+.reveal.cube .slides > section.future {
+  -webkit-transform-origin: 0% 0%;
+          transform-origin: 0% 0%;
+  -webkit-transform: translate3d(100%, 0, 0) rotateY(90deg);
+          transform: translate3d(100%, 0, 0) rotateY(90deg); }
+
+.reveal.cube .slides > section > section.past {
+  -webkit-transform-origin: 0% 100%;
+          transform-origin: 0% 100%;
+  -webkit-transform: translate3d(0, -100%, 0) rotateX(90deg);
+          transform: translate3d(0, -100%, 0) rotateX(90deg); }
+
+.reveal.cube .slides > section > section.future {
+  -webkit-transform-origin: 0% 0%;
+          transform-origin: 0% 0%;
+  -webkit-transform: translate3d(0, 100%, 0) rotateX(-90deg);
+          transform: translate3d(0, 100%, 0) rotateX(-90deg); }
+
+/*********************************************
+ * PAGE TRANSITION
+ *********************************************/
+.reveal.page .slides {
+  -webkit-perspective-origin: 0% 50%;
+          perspective-origin: 0% 50%;
+  -webkit-perspective: 3000px;
+          perspective: 3000px; }
+
+.reveal.page .slides section {
+  padding: 30px;
+  min-height: 700px;
+  box-sizing: border-box; }
+
+.reveal.page .slides section.past {
+  z-index: 12; }
+
+.reveal.page .slides section:not(.stack):before {
+  content: '';
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  background: rgba(0, 0, 0, 0.1);
+  -webkit-transform: translateZ(-20px);
+          transform: translateZ(-20px); }
+
+.reveal.page .slides section:not(.stack):after {
+  content: '';
+  position: absolute;
+  display: block;
+  width: 90%;
+  height: 30px;
+  left: 5%;
+  bottom: 0;
+  background: none;
+  z-index: 1;
+  border-radius: 4px;
+  box-shadow: 0px 95px 25px rgba(0, 0, 0, 0.2);
+  -webkit-transform: translateZ(-90px) rotateX(65deg); }
+
+.reveal.page .slides > section.stack {
+  padding: 0;
+  background: none; }
+
+.reveal.page .slides > section.past {
+  -webkit-transform-origin: 0% 0%;
+          transform-origin: 0% 0%;
+  -webkit-transform: translate3d(-40%, 0, 0) rotateY(-80deg);
+          transform: translate3d(-40%, 0, 0) rotateY(-80deg); }
+
+.reveal.page .slides > section.future {
+  -webkit-transform-origin: 100% 0%;
+          transform-origin: 100% 0%;
+  -webkit-transform: translate3d(0, 0, 0);
+          transform: translate3d(0, 0, 0); }
+
+.reveal.page .slides > section > section.past {
+  -webkit-transform-origin: 0% 0%;
+          transform-origin: 0% 0%;
+  -webkit-transform: translate3d(0, -40%, 0) rotateX(80deg);
+          transform: translate3d(0, -40%, 0) rotateX(80deg); }
+
+.reveal.page .slides > section > section.future {
+  -webkit-transform-origin: 0% 100%;
+          transform-origin: 0% 100%;
+  -webkit-transform: translate3d(0, 0, 0);
+          transform: translate3d(0, 0, 0); }
+
+/*********************************************
+ * FADE TRANSITION
+ *********************************************/
+.reveal .slides section[data-transition=fade],
+.reveal.fade .slides section:not([data-transition]),
+.reveal.fade .slides > section > section:not([data-transition]) {
+  -webkit-transform: none;
+          transform: none;
+  -webkit-transition: opacity 0.5s;
+          transition: opacity 0.5s; }
+
+.reveal.fade.overview .slides section,
+.reveal.fade.overview .slides > section > section {
+  -webkit-transition: none;
+          transition: none; }
+
+/*********************************************
+ * NO TRANSITION
+ *********************************************/
+.reveal .slides section[data-transition=none],
+.reveal.none .slides section:not([data-transition]) {
+  -webkit-transform: none;
+          transform: none;
+  -webkit-transition: none;
+          transition: none; }
+
+/*********************************************
+ * PAUSED MODE
+ *********************************************/
+.reveal .pause-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: black;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 100;
+  -webkit-transition: all 1s ease;
+          transition: all 1s ease; }
+
+.reveal.paused .pause-overlay {
+  visibility: visible;
+  opacity: 1; }
+
+/*********************************************
+ * FALLBACK
+ *********************************************/
+.no-transforms {
+  overflow-y: auto; }
+
+.no-transforms .reveal .slides {
+  position: relative;
+  width: 80%;
+  height: auto !important;
+  top: 0;
+  left: 50%;
+  margin: 0;
+  text-align: center; }
+
+.no-transforms .reveal .controls,
+.no-transforms .reveal .progress {
+  display: none !important; }
+
+.no-transforms .reveal .slides section {
+  display: block !important;
+  opacity: 1 !important;
+  position: relative !important;
+  height: auto;
+  min-height: 0;
+  top: 0;
+  left: -50%;
+  margin: 70px 0;
+  -webkit-transform: none;
+          transform: none; }
+
+.no-transforms .reveal .slides section section {
+  left: 0; }
+
+.reveal .no-transition,
+.reveal .no-transition * {
+  -webkit-transition: none !important;
+          transition: none !important; }
+
+/*********************************************
+ * PER-SLIDE BACKGROUNDS
+ *********************************************/
+.reveal .backgrounds {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  -webkit-perspective: 600px;
+          perspective: 600px; }
+
+.reveal .slide-background {
+  display: none;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  visibility: hidden;
+  background-color: transparent;
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  background-size: cover;
+  -webkit-transition: all 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+          transition: all 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }
+
+.reveal .slide-background.stack {
+  display: block; }
+
+.reveal .slide-background.present {
+  opacity: 1;
+  visibility: visible; }
+
+.print-pdf .reveal .slide-background {
+  opacity: 1 !important;
+  visibility: visible !important; }
+
+/* Video backgrounds */
+.reveal .slide-background video {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  top: 0;
+  left: 0; }
+
+/* Immediate transition style */
+.reveal[data-background-transition=none] > .backgrounds .slide-background,
+.reveal > .backgrounds .slide-background[data-background-transition=none] {
+  -webkit-transition: none;
+          transition: none; }
+
+/* Slide */
+.reveal[data-background-transition=slide] > .backgrounds .slide-background,
+.reveal > .backgrounds .slide-background[data-background-transition=slide] {
+  opacity: 1;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+
+.reveal[data-background-transition=slide] > .backgrounds .slide-background.past,
+.reveal > .backgrounds .slide-background.past[data-background-transition=slide] {
+  -webkit-transform: translate(-100%, 0);
+          transform: translate(-100%, 0); }
+
+.reveal[data-background-transition=slide] > .backgrounds .slide-background.future,
+.reveal > .backgrounds .slide-background.future[data-background-transition=slide] {
+  -webkit-transform: translate(100%, 0);
+          transform: translate(100%, 0); }
+
+.reveal[data-background-transition=slide] > .backgrounds .slide-background > .slide-background.past,
+.reveal > .backgrounds .slide-background > .slide-background.past[data-background-transition=slide] {
+  -webkit-transform: translate(0, -100%);
+          transform: translate(0, -100%); }
+
+.reveal[data-background-transition=slide] > .backgrounds .slide-background > .slide-background.future,
+.reveal > .backgrounds .slide-background > .slide-background.future[data-background-transition=slide] {
+  -webkit-transform: translate(0, 100%);
+          transform: translate(0, 100%); }
+
+/* Convex */
+.reveal[data-background-transition=convex] > .backgrounds .slide-background.past,
+.reveal > .backgrounds .slide-background.past[data-background-transition=convex] {
+  opacity: 0;
+  -webkit-transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0);
+          transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
+
+.reveal[data-background-transition=convex] > .backgrounds .slide-background.future,
+.reveal > .backgrounds .slide-background.future[data-background-transition=convex] {
+  opacity: 0;
+  -webkit-transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0);
+          transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
+
+.reveal[data-background-transition=convex] > .backgrounds .slide-background > .slide-background.past,
+.reveal > .backgrounds .slide-background > .slide-background.past[data-background-transition=convex] {
+  opacity: 0;
+  -webkit-transform: translate3d(0, -100%, 0) rotateX(90deg) translate3d(0, -100%, 0);
+          transform: translate3d(0, -100%, 0) rotateX(90deg) translate3d(0, -100%, 0); }
+
+.reveal[data-background-transition=convex] > .backgrounds .slide-background > .slide-background.future,
+.reveal > .backgrounds .slide-background > .slide-background.future[data-background-transition=convex] {
+  opacity: 0;
+  -webkit-transform: translate3d(0, 100%, 0) rotateX(-90deg) translate3d(0, 100%, 0);
+          transform: translate3d(0, 100%, 0) rotateX(-90deg) translate3d(0, 100%, 0); }
+
+/* Concave */
+.reveal[data-background-transition=concave] > .backgrounds .slide-background.past,
+.reveal > .backgrounds .slide-background.past[data-background-transition=concave] {
+  opacity: 0;
+  -webkit-transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0);
+          transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0); }
+
+.reveal[data-background-transition=concave] > .backgrounds .slide-background.future,
+.reveal > .backgrounds .slide-background.future[data-background-transition=concave] {
+  opacity: 0;
+  -webkit-transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0);
+          transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0); }
+
+.reveal[data-background-transition=concave] > .backgrounds .slide-background > .slide-background.past,
+.reveal > .backgrounds .slide-background > .slide-background.past[data-background-transition=concave] {
+  opacity: 0;
+  -webkit-transform: translate3d(0, -100%, 0) rotateX(-90deg) translate3d(0, -100%, 0);
+          transform: translate3d(0, -100%, 0) rotateX(-90deg) translate3d(0, -100%, 0); }
+
+.reveal[data-background-transition=concave] > .backgrounds .slide-background > .slide-background.future,
+.reveal > .backgrounds .slide-background > .slide-background.future[data-background-transition=concave] {
+  opacity: 0;
+  -webkit-transform: translate3d(0, 100%, 0) rotateX(90deg) translate3d(0, 100%, 0);
+          transform: translate3d(0, 100%, 0) rotateX(90deg) translate3d(0, 100%, 0); }
+
+/* Zoom */
+.reveal[data-background-transition=zoom] > .backgrounds .slide-background,
+.reveal > .backgrounds .slide-background[data-background-transition=zoom] {
+  -webkit-transition-timing-function: ease;
+          transition-timing-function: ease; }
+
+.reveal[data-background-transition=zoom] > .backgrounds .slide-background.past,
+.reveal > .backgrounds .slide-background.past[data-background-transition=zoom] {
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transform: scale(16);
+          transform: scale(16); }
+
+.reveal[data-background-transition=zoom] > .backgrounds .slide-background.future,
+.reveal > .backgrounds .slide-background.future[data-background-transition=zoom] {
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transform: scale(0.2);
+          transform: scale(0.2); }
+
+.reveal[data-background-transition=zoom] > .backgrounds .slide-background > .slide-background.past,
+.reveal > .backgrounds .slide-background > .slide-background.past[data-background-transition=zoom] {
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transform: scale(16);
+          transform: scale(16); }
+
+.reveal[data-background-transition=zoom] > .backgrounds .slide-background > .slide-background.future,
+.reveal > .backgrounds .slide-background > .slide-background.future[data-background-transition=zoom] {
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transform: scale(0.2);
+          transform: scale(0.2); }
+
+/* Global transition speed settings */
+.reveal[data-transition-speed="fast"] > .backgrounds .slide-background {
+  -webkit-transition-duration: 400ms;
+          transition-duration: 400ms; }
+
+.reveal[data-transition-speed="slow"] > .backgrounds .slide-background {
+  -webkit-transition-duration: 1200ms;
+          transition-duration: 1200ms; }
+
+/*********************************************
+ * OVERVIEW
+ *********************************************/
+.reveal.overview {
+  -webkit-perspective-origin: 50% 50%;
+          perspective-origin: 50% 50%;
+  -webkit-perspective: 700px;
+          perspective: 700px; }
+  .reveal.overview .slides section {
+    height: 100%;
+    top: 0 !important;
+    opacity: 1 !important;
+    overflow: hidden;
+    visibility: visible !important;
+    cursor: pointer;
+    box-sizing: border-box; }
+  .reveal.overview .slides section:hover,
+  .reveal.overview .slides section.present {
+    outline: 10px solid rgba(150, 150, 150, 0.4);
+    outline-offset: 10px; }
+  .reveal.overview .slides section .fragment {
+    opacity: 1;
+    -webkit-transition: none;
+            transition: none; }
+  .reveal.overview .slides section:after,
+  .reveal.overview .slides section:before {
+    display: none !important; }
+  .reveal.overview .slides > section.stack {
+    padding: 0;
+    top: 0 !important;
+    background: none;
+    outline: none;
+    overflow: visible; }
+  .reveal.overview .backgrounds {
+    -webkit-perspective: inherit;
+            perspective: inherit; }
+  .reveal.overview .backgrounds .slide-background {
+    opacity: 1;
+    visibility: visible;
+    outline: 10px solid rgba(150, 150, 150, 0.1);
+    outline-offset: 10px; }
+
+.reveal.overview .slides section,
+.reveal.overview-deactivating .slides section {
+  -webkit-transition: none;
+          transition: none; }
+
+.reveal.overview .backgrounds .slide-background,
+.reveal.overview-deactivating .backgrounds .slide-background {
+  -webkit-transition: none;
+          transition: none; }
+
+.reveal.overview-animated .slides {
+  -webkit-transition: -webkit-transform 0.4s ease;
+          transition: transform 0.4s ease; }
+
+/*********************************************
+ * RTL SUPPORT
+ *********************************************/
+.reveal.rtl .slides,
+.reveal.rtl .slides h1,
+.reveal.rtl .slides h2,
+.reveal.rtl .slides h3,
+.reveal.rtl .slides h4,
+.reveal.rtl .slides h5,
+.reveal.rtl .slides h6 {
+  direction: rtl;
+  font-family: sans-serif; }
+
+.reveal.rtl pre,
+.reveal.rtl code {
+  direction: ltr; }
+
+.reveal.rtl ol,
+.reveal.rtl ul {
+  text-align: right; }
+
+.reveal.rtl .progress span {
+  float: right; }
+
+/*********************************************
+ * PARALLAX BACKGROUND
+ *********************************************/
+.reveal.has-parallax-background .backgrounds {
+  -webkit-transition: all 0.8s ease;
+          transition: all 0.8s ease; }
+
+/* Global transition speed settings */
+.reveal.has-parallax-background[data-transition-speed="fast"] .backgrounds {
+  -webkit-transition-duration: 400ms;
+          transition-duration: 400ms; }
+
+.reveal.has-parallax-background[data-transition-speed="slow"] .backgrounds {
+  -webkit-transition-duration: 1200ms;
+          transition-duration: 1200ms; }
+
+/*********************************************
+ * LINK PREVIEW OVERLAY
+ *********************************************/
+.reveal .overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.9);
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: all 0.3s ease;
+          transition: all 0.3s ease; }
+
+.reveal .overlay.visible {
+  opacity: 1;
+  visibility: visible; }
+
+.reveal .overlay .spinner {
+  position: absolute;
+  display: block;
+  top: 50%;
+  left: 50%;
+  width: 32px;
+  height: 32px;
+  margin: -16px 0 0 -16px;
+  z-index: 10;
+  background-image: url(data:image/gif;base64,R0lGODlhIAAgAPMAAJmZmf%2F%2F%2F6%2Bvr8nJybW1tcDAwOjo6Nvb26ioqKOjo7Ozs%2FLy8vz8%2FAAAAAAAAAAAACH%2FC05FVFNDQVBFMi4wAwEAAAAh%2FhpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh%2BQQJCgAAACwAAAAAIAAgAAAE5xDISWlhperN52JLhSSdRgwVo1ICQZRUsiwHpTJT4iowNS8vyW2icCF6k8HMMBkCEDskxTBDAZwuAkkqIfxIQyhBQBFvAQSDITM5VDW6XNE4KagNh6Bgwe60smQUB3d4Rz1ZBApnFASDd0hihh12BkE9kjAJVlycXIg7CQIFA6SlnJ87paqbSKiKoqusnbMdmDC2tXQlkUhziYtyWTxIfy6BE8WJt5YJvpJivxNaGmLHT0VnOgSYf0dZXS7APdpB309RnHOG5gDqXGLDaC457D1zZ%2FV%2FnmOM82XiHRLYKhKP1oZmADdEAAAh%2BQQJCgAAACwAAAAAIAAgAAAE6hDISWlZpOrNp1lGNRSdRpDUolIGw5RUYhhHukqFu8DsrEyqnWThGvAmhVlteBvojpTDDBUEIFwMFBRAmBkSgOrBFZogCASwBDEY%2FCZSg7GSE0gSCjQBMVG023xWBhklAnoEdhQEfyNqMIcKjhRsjEdnezB%2BA4k8gTwJhFuiW4dokXiloUepBAp5qaKpp6%2BHo7aWW54wl7obvEe0kRuoplCGepwSx2jJvqHEmGt6whJpGpfJCHmOoNHKaHx61WiSR92E4lbFoq%2BB6QDtuetcaBPnW6%2BO7wDHpIiK9SaVK5GgV543tzjgGcghAgAh%2BQQJCgAAACwAAAAAIAAgAAAE7hDISSkxpOrN5zFHNWRdhSiVoVLHspRUMoyUakyEe8PTPCATW9A14E0UvuAKMNAZKYUZCiBMuBakSQKG8G2FzUWox2AUtAQFcBKlVQoLgQReZhQlCIJesQXI5B0CBnUMOxMCenoCfTCEWBsJColTMANldx15BGs8B5wlCZ9Po6OJkwmRpnqkqnuSrayqfKmqpLajoiW5HJq7FL1Gr2mMMcKUMIiJgIemy7xZtJsTmsM4xHiKv5KMCXqfyUCJEonXPN2rAOIAmsfB3uPoAK%2B%2BG%2Bw48edZPK%2BM6hLJpQg484enXIdQFSS1u6UhksENEQAAIfkECQoAAAAsAAAAACAAIAAABOcQyEmpGKLqzWcZRVUQnZYg1aBSh2GUVEIQ2aQOE%2BG%2BcD4ntpWkZQj1JIiZIogDFFyHI0UxQwFugMSOFIPJftfVAEoZLBbcLEFhlQiqGp1Vd140AUklUN3eCA51C1EWMzMCezCBBmkxVIVHBWd3HHl9JQOIJSdSnJ0TDKChCwUJjoWMPaGqDKannasMo6WnM562R5YluZRwur0wpgqZE7NKUm%2BFNRPIhjBJxKZteWuIBMN4zRMIVIhffcgojwCF117i4nlLnY5ztRLsnOk%2BaV%2BoJY7V7m76PdkS4trKcdg0Zc0tTcKkRAAAIfkECQoAAAAsAAAAACAAIAAABO4QyEkpKqjqzScpRaVkXZWQEximw1BSCUEIlDohrft6cpKCk5xid5MNJTaAIkekKGQkWyKHkvhKsR7ARmitkAYDYRIbUQRQjWBwJRzChi9CRlBcY1UN4g0%2FVNB0AlcvcAYHRyZPdEQFYV8ccwR5HWxEJ02YmRMLnJ1xCYp0Y5idpQuhopmmC2KgojKasUQDk5BNAwwMOh2RtRq5uQuPZKGIJQIGwAwGf6I0JXMpC8C7kXWDBINFMxS4DKMAWVWAGYsAdNqW5uaRxkSKJOZKaU3tPOBZ4DuK2LATgJhkPJMgTwKCdFjyPHEnKxFCDhEAACH5BAkKAAAALAAAAAAgACAAAATzEMhJaVKp6s2nIkolIJ2WkBShpkVRWqqQrhLSEu9MZJKK9y1ZrqYK9WiClmvoUaF8gIQSNeF1Er4MNFn4SRSDARWroAIETg1iVwuHjYB1kYc1mwruwXKC9gmsJXliGxc%2BXiUCby9ydh1sOSdMkpMTBpaXBzsfhoc5l58Gm5yToAaZhaOUqjkDgCWNHAULCwOLaTmzswadEqggQwgHuQsHIoZCHQMMQgQGubVEcxOPFAcMDAYUA85eWARmfSRQCdcMe0zeP1AAygwLlJtPNAAL19DARdPzBOWSm1brJBi45soRAWQAAkrQIykShQ9wVhHCwCQCACH5BAkKAAAALAAAAAAgACAAAATrEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq%2BE71SRQeyqUToLA7VxF0JDyIQh%2FMVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiRMDjI0Fd30%2FiI2UA5GSS5UDj2l6NoqgOgN4gksEBgYFf0FDqKgHnyZ9OX8HrgYHdHpcHQULXAS2qKpENRg7eAMLC7kTBaixUYFkKAzWAAnLC7FLVxLWDBLKCwaKTULgEwbLA4hJtOkSBNqITT3xEgfLpBtzE%2FjiuL04RGEBgwWhShRgQExHBAAh%2BQQJCgAAACwAAAAAIAAgAAAE7xDISWlSqerNpyJKhWRdlSAVoVLCWk6JKlAqAavhO9UkUHsqlE6CwO1cRdCQ8iEIfzFVTzLdRAmZX3I2SfZiCqGk5dTESJeaOAlClzsJsqwiJwiqnFrb2nS9kmIcgEsjQydLiIlHehhpejaIjzh9eomSjZR%2BipslWIRLAgMDOR2DOqKogTB9pCUJBagDBXR6XB0EBkIIsaRsGGMMAxoDBgYHTKJiUYEGDAzHC9EACcUGkIgFzgwZ0QsSBcXHiQvOwgDdEwfFs0sDzt4S6BK4xYjkDOzn0unFeBzOBijIm1Dgmg5YFQwsCMjp1oJ8LyIAACH5BAkKAAAALAAAAAAgACAAAATwEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq%2BE71SRQeyqUToLA7VxF0JDyIQh%2FMVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiUd6GGl6NoiPOH16iZKNlH6KmyWFOggHhEEvAwwMA0N9GBsEC6amhnVcEwavDAazGwIDaH1ipaYLBUTCGgQDA8NdHz0FpqgTBwsLqAbWAAnIA4FWKdMLGdYGEgraigbT0OITBcg5QwPT4xLrROZL6AuQAPUS7bxLpoWidY0JtxLHKhwwMJBTHgPKdEQAACH5BAkKAAAALAAAAAAgACAAAATrEMhJaVKp6s2nIkqFZF2VIBWhUsJaTokqUCoBq%2BE71SRQeyqUToLA7VxF0JDyIQh%2FMVVPMt1ECZlfcjZJ9mIKoaTl1MRIl5o4CUKXOwmyrCInCKqcWtvadL2SYhyASyNDJ0uIiUd6GAULDJCRiXo1CpGXDJOUjY%2BYip9DhToJA4RBLwMLCwVDfRgbBAaqqoZ1XBMHswsHtxtFaH1iqaoGNgAIxRpbFAgfPQSqpbgGBqUD1wBXeCYp1AYZ19JJOYgH1KwA4UBvQwXUBxPqVD9L3sbp2BNk2xvvFPJd%2BMFCN6HAAIKgNggY0KtEBAAh%2BQQJCgAAACwAAAAAIAAgAAAE6BDISWlSqerNpyJKhWRdlSAVoVLCWk6JKlAqAavhO9UkUHsqlE6CwO1cRdCQ8iEIfzFVTzLdRAmZX3I2SfYIDMaAFdTESJeaEDAIMxYFqrOUaNW4E4ObYcCXaiBVEgULe0NJaxxtYksjh2NLkZISgDgJhHthkpU4mW6blRiYmZOlh4JWkDqILwUGBnE6TYEbCgevr0N1gH4At7gHiRpFaLNrrq8HNgAJA70AWxQIH1%2BvsYMDAzZQPC9VCNkDWUhGkuE5PxJNwiUK4UfLzOlD4WvzAHaoG9nxPi5d%2BjYUqfAhhykOFwJWiAAAIfkECQoAAAAsAAAAACAAIAAABPAQyElpUqnqzaciSoVkXVUMFaFSwlpOCcMYlErAavhOMnNLNo8KsZsMZItJEIDIFSkLGQoQTNhIsFehRww2CQLKF0tYGKYSg%2BygsZIuNqJksKgbfgIGepNo2cIUB3V1B3IvNiBYNQaDSTtfhhx0CwVPI0UJe0%2Bbm4g5VgcGoqOcnjmjqDSdnhgEoamcsZuXO1aWQy8KAwOAuTYYGwi7w5h%2BKr0SJ8MFihpNbx%2B4Erq7BYBuzsdiH1jCAzoSfl0rVirNbRXlBBlLX%2BBP0XJLAPGzTkAuAOqb0WT5AH7OcdCm5B8TgRwSRKIHQtaLCwg1RAAAOwAAAAAAAAAAAA%3D%3D);
+  visibility: visible;
+  opacity: 0.6;
+  -webkit-transition: all 0.3s ease;
+          transition: all 0.3s ease; }
+
+.reveal .overlay header {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 40px;
+  z-index: 2;
+  border-bottom: 1px solid #222; }
+
+.reveal .overlay header a {
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  padding: 0 10px;
+  float: right;
+  opacity: 0.6;
+  box-sizing: border-box; }
+
+.reveal .overlay header a:hover {
+  opacity: 1; }
+
+.reveal .overlay header a .icon {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background-position: 50% 50%;
+  background-size: 100%;
+  background-repeat: no-repeat; }
+
+.reveal .overlay header a.close .icon {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABkklEQVRYR8WX4VHDMAxG6wnoJrABZQPYBCaBTWAD2g1gE5gg6OOsXuxIlr40d81dfrSJ9V4c2VLK7spHuTJ/5wpM07QXuXc5X0opX2tEJcadjHuV80li/FgxTIEK/5QBCICBD6xEhSMGHgQPgBgLiYVAB1dpSqKDawxTohFw4JSEA3clzgIBPCURwE2JucBR7rhPJJv5OpJwDX+SfDjgx1wACQeJG1aChP9K/IMmdZ8DtESV1WyP3Bt4MwM6sj4NMxMYiqUWHQu4KYA/SYkIjOsm3BXYWMKFDwU2khjCQ4ELJUJ4SmClRArOCmSXGuKma0fYD5CbzHxFpCSGAhfAVSSUGDUk2BWZaff2g6GE15BsBQ9nwmpIGDiyHQddwNTMKkbZaf9fajXQca1EX44puJZUsnY0ObGmITE3GVLCbEhQUjGVt146j6oasWN+49Vph2w1pZ5EansNZqKBm1txbU57iRRcZ86RWMDdWtBJUHBHwoQPi1GV+JCbntmvok7iTX4/Up9mgyTc/FJYDTcndgH/AA5A/CHsyEkVAAAAAElFTkSuQmCC); }
+
+.reveal .overlay header a.external .icon {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAcElEQVRYR+2WSQoAIQwEzf8f7XiOMkUQxUPlGkM3hVmiQfQR9GYnH1SsAQlI4DiBqkCMoNb9y2e90IAEJPAcgdznU9+engMaeJ7Azh5Y1U67gAho4DqBqmB1buAf0MB1AlVBek83ZPkmJMGc1wAR+AAqod/B97TRpQAAAABJRU5ErkJggg==); }
+
+.reveal .overlay .viewport {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 40px;
+  right: 0;
+  bottom: 0;
+  left: 0; }
+
+.reveal .overlay.overlay-preview .viewport iframe {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  border: 0;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: all 0.3s ease;
+          transition: all 0.3s ease; }
+
+.reveal .overlay.overlay-preview.loaded .viewport iframe {
+  opacity: 1;
+  visibility: visible; }
+
+.reveal .overlay.overlay-preview.loaded .spinner {
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transform: scale(0.2);
+          transform: scale(0.2); }
+
+.reveal .overlay.overlay-help .viewport {
+  overflow: auto;
+  color: #fff; }
+
+.reveal .overlay.overlay-help .viewport .viewport-inner {
+  width: 600px;
+  margin: auto;
+  padding: 20px 20px 80px 20px;
+  text-align: center;
+  letter-spacing: normal; }
+
+.reveal .overlay.overlay-help .viewport .viewport-inner .title {
+  font-size: 20px; }
+
+.reveal .overlay.overlay-help .viewport .viewport-inner table {
+  border: 1px solid #fff;
+  border-collapse: collapse;
+  font-size: 16px; }
+
+.reveal .overlay.overlay-help .viewport .viewport-inner table th,
+.reveal .overlay.overlay-help .viewport .viewport-inner table td {
+  width: 200px;
+  padding: 14px;
+  border: 1px solid #fff;
+  vertical-align: middle; }
+
+.reveal .overlay.overlay-help .viewport .viewport-inner table th {
+  padding-top: 20px;
+  padding-bottom: 20px; }
+
+/*********************************************
+ * PLAYBACK COMPONENT
+ *********************************************/
+.reveal .playback {
+  position: fixed;
+  left: 15px;
+  bottom: 20px;
+  z-index: 30;
+  cursor: pointer;
+  -webkit-transition: all 400ms ease;
+          transition: all 400ms ease; }
+
+.reveal.overview .playback {
+  opacity: 0;
+  visibility: hidden; }
+
+/*********************************************
+ * ROLLING LINKS
+ *********************************************/
+.reveal .roll {
+  display: inline-block;
+  line-height: 1.2;
+  overflow: hidden;
+  vertical-align: top;
+  -webkit-perspective: 400px;
+          perspective: 400px;
+  -webkit-perspective-origin: 50% 50%;
+          perspective-origin: 50% 50%; }
+
+.reveal .roll:hover {
+  background: none;
+  text-shadow: none; }
+
+.reveal .roll span {
+  display: block;
+  position: relative;
+  padding: 0 2px;
+  pointer-events: none;
+  -webkit-transition: all 400ms ease;
+          transition: all 400ms ease;
+  -webkit-transform-origin: 50% 0%;
+          transform-origin: 50% 0%;
+  -webkit-transform-style: preserve-3d;
+          transform-style: preserve-3d;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden; }
+
+.reveal .roll:hover span {
+  background: rgba(0, 0, 0, 0.5);
+  -webkit-transform: translate3d(0px, 0px, -45px) rotateX(90deg);
+          transform: translate3d(0px, 0px, -45px) rotateX(90deg); }
+
+.reveal .roll span:after {
+  content: attr(data-title);
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  padding: 0 2px;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
+  -webkit-transform-origin: 50% 0%;
+          transform-origin: 50% 0%;
+  -webkit-transform: translate3d(0px, 110%, 0px) rotateX(-90deg);
+          transform: translate3d(0px, 110%, 0px) rotateX(-90deg); }
+
+/*********************************************
+ * SPEAKER NOTES
+ *********************************************/
+.reveal aside.notes {
+  display: none; }
+
+.reveal .speaker-notes {
+  display: none;
+  position: absolute;
+  width: 70%;
+  max-height: 15%;
+  left: 15%;
+  bottom: 26px;
+  padding: 10px;
+  z-index: 1;
+  font-size: 18px;
+  line-height: 1.4;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.5);
+  overflow: auto;
+  box-sizing: border-box;
+  text-align: left;
+  font-family: Helvetica, sans-serif;
+  -webkit-overflow-scrolling: touch; }
+
+.reveal .speaker-notes.visible:not(:empty) {
+  display: block; }
+
+@media screen and (max-width: 1024px) {
+  .reveal .speaker-notes {
+    font-size: 14px; } }
+
+@media screen and (max-width: 600px) {
+  .reveal .speaker-notes {
+    width: 90%;
+    left: 5%; } }
+
+/*********************************************
+ * ZOOM PLUGIN
+ *********************************************/
+.zoomed .reveal *,
+.zoomed .reveal *:before,
+.zoomed .reveal *:after {
+  -webkit-backface-visibility: visible !important;
+          backface-visibility: visible !important; }
+
+.zoomed .reveal .progress,
+.zoomed .reveal .controls {
+  opacity: 0; }
+
+.zoomed .reveal .roll span {
+  background: none; }
+
+.zoomed .reveal .roll span:after {
+  visibility: hidden; }

--- a/app/scss/reveal.css
+++ b/app/scss/reveal.css
@@ -13,9 +13,10 @@
  * Updated by William:
  *   - removed html, body below
  *   - removed global style
+ *   - removed .reveal span
  */
 
-.reveal div, .reveal span, .reveal applet, .reveal object, .reveal iframe,
+.reveal div, .reveal applet, .reveal object, .reveal iframe,
 .reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6, .reveal p, .reveal blockquote, .reveal pre,
 .reveal a, .reveal abbr, .reveal acronym, .reveal address, .reveal big, .reveal cite, .reveal code,
 .reveal del, .reveal dfn, .reveal em, .reveal img, .reveal ins, .reveal kbd, .reveal q, .reveal s, .reveal samp,
@@ -753,7 +754,7 @@ html:-moz-full-screen-ancestor {
  * PAUSED MODE
  *********************************************/
 .reveal .pause-overlay {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
@@ -1062,22 +1063,6 @@ html:-moz-full-screen-ancestor {
   float: right; }
 
 /*********************************************
- * PARALLAX BACKGROUND
- *********************************************/
-.reveal.has-parallax-background .backgrounds {
-  -webkit-transition: all 0.8s ease;
-          transition: all 0.8s ease; }
-
-/* Global transition speed settings */
-.reveal.has-parallax-background[data-transition-speed="fast"] .backgrounds {
-  -webkit-transition-duration: 400ms;
-          transition-duration: 400ms; }
-
-.reveal.has-parallax-background[data-transition-speed="slow"] .backgrounds {
-  -webkit-transition-duration: 1200ms;
-          transition-duration: 1200ms; }
-
-/*********************************************
  * LINK PREVIEW OVERLAY
  *********************************************/
 .reveal .overlay {
@@ -1274,59 +1259,3 @@ html:-moz-full-screen-ancestor {
           transform-origin: 50% 0%;
   -webkit-transform: translate3d(0px, 110%, 0px) rotateX(-90deg);
           transform: translate3d(0px, 110%, 0px) rotateX(-90deg); }
-
-/*********************************************
- * SPEAKER NOTES
- *********************************************/
-.reveal aside.notes {
-  display: none; }
-
-.reveal .speaker-notes {
-  display: none;
-  position: absolute;
-  width: 70%;
-  max-height: 15%;
-  left: 15%;
-  bottom: 26px;
-  padding: 10px;
-  z-index: 1;
-  font-size: 18px;
-  line-height: 1.4;
-  color: #fff;
-  background-color: rgba(0, 0, 0, 0.5);
-  overflow: auto;
-  box-sizing: border-box;
-  text-align: left;
-  font-family: Helvetica, sans-serif;
-  -webkit-overflow-scrolling: touch; }
-
-.reveal .speaker-notes.visible:not(:empty) {
-  display: block; }
-
-@media screen and (max-width: 1024px) {
-  .reveal .speaker-notes {
-    font-size: 14px; } }
-
-@media screen and (max-width: 600px) {
-  .reveal .speaker-notes {
-    width: 90%;
-    left: 5%; } }
-
-/*********************************************
- * ZOOM PLUGIN
- *********************************************/
-.zoomed .reveal *,
-.zoomed .reveal *:before,
-.zoomed .reveal *:after {
-  -webkit-backface-visibility: visible !important;
-          backface-visibility: visible !important; }
-
-.zoomed .reveal .progress,
-.zoomed .reveal .controls {
-  opacity: 0; }
-
-.zoomed .reveal .roll span {
-  background: none; }
-
-.zoomed .reveal .roll span:after {
-  visibility: hidden; }

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -4,6 +4,7 @@ Templates
 * [Letter](#letter)
 * [Invoice](#invoice)
 * [Report](#report)
+* [Slide deck](#slide-deck)
 
 
 ## Letter
@@ -76,6 +77,20 @@ date:
 location:
 reference:
 version:
+---
+```
+
+## Slide deck
+
+The "Slide deck" template helps you write awesome
+[Reveal.js](https://github.com/hakimel/reveal.js)-based slides. In your Markdown
+content, use a separator `---` to split your content into different slides.
+
+### YAML Front-Matter
+
+```
+---
+transition: zoom # None, Fade, Slide, Convex, Concave, Zoom
 ---
 ```
 

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -88,7 +88,7 @@ content, use a separator `---` (3 dashes) to split your content into different
 **sections** (horizontally, like regular slide decks).
 
 Thanks to Reveal.js, it is also possible to group slides into **sub-sections**
-that are displayed vertically. Use the `----` (4 dashes) to create sub-sections.
+that are displayed vertically. Use `----` (4 dashes) to create sub-sections.
 
 **Example:**
 

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -84,7 +84,38 @@ version:
 
 The "Slide deck" template helps you write awesome
 [Reveal.js](https://github.com/hakimel/reveal.js)-based slides. In your Markdown
-content, use a separator `---` to split your content into different slides.
+content, use a separator `---` (3 dashes) to split your content into different
+**sections** (horizontally, like regular slide decks).
+
+Thanks to Reveal.js, it is also possible to group slides into **sub-sections**
+that are displayed vertically. Use the `----` (4 dashes) to create sub-sections.
+
+**Example:**
+
+```markdown
+Slide 1.0
+
+---
+
+Slide 2.0
+
+----
+
+Slide 2.1
+
+----
+
+Slide 2.2
+
+---
+
+Slide 3.0
+
+----
+
+Slide 3.1
+```
+
 
 ### YAML Front-Matter
 

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -117,5 +117,44 @@ transition: default
 {fragment}
 ```
 
+### Style
+
+#### Images
+
+It is possible to hide the border of an image by using the `{no-border}` special
+notation below the image:
+
+```markdown
+![](https://example.org/foobar.png)
+{no-border}
+```
+
+#### Lists
+
+It is possible to hide the bullets of a list by using the `{no-bullets}` special
+notation:
+
+```markdown
+Isaac Asimov's "Three Laws of Robotics":
+
+* A robot may not injure a human being or, through inaction, allow a human being
+  to come to harm;
+* A robot must obey orders given it by human beings except where such orders
+  would conflict with the First Law;
+* A robot must protect its own existence as long as such protection does not
+  conflict with the First or Second Law.
+{no-bullets}
+```
+
+#### Paragraphs
+
+You can choose the paragraph alignment using the following special notations
+on paragraphs (default being centered):
+
+* `{left}`
+* `{right}`
+* `{justify}`
+
+
 ---
 Back to: [Writing Monod documents](writing.md)

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -94,5 +94,28 @@ transition: zoom # None, Fade, Slide, Convex, Concave, Zoom
 ---
 ```
 
+### Fragments
+
+[Fragments](https://github.com/hakimel/reveal.js#fragments) are used to
+highlight individual elements on a slide. You can use the `{fragment}` special
+notation below any sentence or paragraph, and it will become a fragment.
+
+``` markdown
+---
+transition: default
+---
+
+# Key metrics are:
+
+* Fragment 1
+{fragment}
+
+* Fragment 2
+{fragment}
+
+* Fragment 3
+{fragment}
+```
+
 ---
 Back to: [Writing Monod documents](writing.md)

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-addons-test-utils": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-loader": "^2.1.0",
+    "reveal.js": "^3.3.0",
     "sass-loader": "^3.1.2",
     "sinon": "^1.17.3",
     "sjcl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lodash.isequal": "^4.1.1",
     "markdown-it": "^6.0.0",
     "markdown-it-abbr": "^1.0.3",
+    "markdown-it-classy": "^0.2.0",
     "markdown-it-container": "^2.0.0",
     "markdown-it-fontawesome": "^0.2.0",
     "markdown-it-ins": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lodash.isequal": "^4.1.1",
     "markdown-it": "^6.0.0",
     "markdown-it-abbr": "^1.0.3",
+    "markdown-it-container": "^2.0.0",
     "markdown-it-fontawesome": "^0.2.0",
     "markdown-it-ins": "^2.0.0",
     "markdown-it-katex": "^2.0.1",


### PR DESCRIPTION
* [x] POC
* [x] support sub-sections (vertical slides)
* [x] tests
* [x] Pretty CSS
* [x] Fullscreen mode (=> presentation mode)
* [x] Fix template select box
* [x] Customize Reveal theme (WIP)
* [x] Add doc

## Features

* Write slides in Markdown
* Code, FontAwesome, KaTeX (Math symbols), Emoji are supported
* Transitions are configurable (in YAML front matter)
* New presentation mode (for all templates, not only slide deck)
* Convert any Markdown text into a slide deck (use `---` for horizontal slides, and `----` for vertical ones)
* Fragments are supported

## Editing mode
![screen shot 2016-06-25 at 16 53 03](https://cloud.githubusercontent.com/assets/217628/16357382/8747bf0e-3af5-11e6-9f0a-87b63961bae8.png)

## Fullscreen mode

![screen shot 2016-06-25 at 16 55 15](https://cloud.githubusercontent.com/assets/217628/16357391/a06a39b2-3af5-11e6-9210-33ca41eb9388.png)

## Presentation mode

![screen shot 2016-06-27 at 19 20 06](https://cloud.githubusercontent.com/assets/217628/16389006/30009664-3c9c-11e6-9f6e-cfa343d83e18.png)
