### PR TITLE
[WIP] Read Only view

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -116,7 +116,7 @@ export default class App extends Component {
 
     this.props.route.controller.dispatch('action:init', {
       id: this.props.params.uuid,
-      secret: window.location.hash.slice(1)
+      secret: this.getSecret(),
     });
   }
 
@@ -140,6 +140,18 @@ export default class App extends Component {
         requestMethod.apply(element);
       }
     }
+  }
+
+  getSecret() {
+    return window.location.hash.slice(1);
+  }
+
+  getFullAccessURL(state) {
+    return `${window.location.origin}/${state.document.uuid}#${this.getSecret()}`;
+  }
+
+  getReadOnlyURL(state) {
+    return `${window.location.origin}/r/${state.document.uuid}#${this.getSecret()}`;
   }
 
   isReadOnly() {
@@ -205,16 +217,12 @@ export default class App extends Component {
         <ShareModal
           isOpen={this.state.displayShareModal}
           onRequestClose={this.toggleShareModal}
-          fullAccessURL={window.location.toString()}
+          fullAccessURL={this.getFullAccessURL(this.state)}
+          readOnlyURL={this.getReadOnlyURL(this.state)}
         />
         <MessageBoxes
           messages={this.state.messages}
           closeMessageBox={this.removeMessage.bind(this)}
-        />
-        <ShareModal
-          isOpen={this.state.displayShareModal}
-          onRequestClose={this.toggleShareModal}
-          fullAccessURL={window.location.toString()}
         />
         {this.props.children && React.cloneElement(this.props.children, {
           loaded: this.state.loaded,

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -19,6 +19,7 @@ Header.propTypes = {
   onUpdateTemplate: func.isRequired,
   onToggleShareModal: func.isRequired,
   enableShareModalButton: bool.isRequired,
+  readOnly: bool.isRequired,
 };
 
 export default Header;

--- a/app/components/Preview.jsx
+++ b/app/components/Preview.jsx
@@ -117,7 +117,7 @@ export default class Preview extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.$rendered) {
+    if (!this.$rendered || -1 === nextProps.pos) {
       return;
     }
 

--- a/app/components/ReadOnly/index.jsx
+++ b/app/components/ReadOnly/index.jsx
@@ -1,0 +1,25 @@
+import React, { PropTypes } from 'react';
+import Loader from 'react-loader';
+import Preview from '../Preview';
+
+
+const ReadOnly = (props) =>
+  <div className="editor">
+    <Loader
+      loaded={props.loaded}
+    />
+    <Preview
+      pos={-1}
+      raw={props.content}
+      template={props.template}
+    />
+  </div>
+;
+
+ReadOnly.propTypes = {
+  loaded: PropTypes.bool.isRequired,
+  content: PropTypes.string.isRequired,
+  template: PropTypes.string.isRequired,
+};
+
+export default ReadOnly;

--- a/app/components/ShareModal/index.jsx
+++ b/app/components/ShareModal/index.jsx
@@ -33,6 +33,23 @@ const ShareModal = (props) =>
         name="monod-full-access"
         value={props.fullAccessURL}
       />
+
+      <h4>Read Only</h4>
+      <p>
+        Anyone with the link below is able to <strong>only</strong> read
+        your Monod document (
+        <a
+          href={props.readOnlyURL}
+          target="_blank"
+          rel="noopener noreferrer">
+          preview&nbsp;<i className="fa fa-external-link" />
+        </a>
+        ):
+      </p>
+      <CopiableUrlInput
+        name="monod-read-only-access"
+        value={props.readOnlyURL}
+      />
     </div>
   </Modal>
 ;
@@ -41,6 +58,7 @@ ShareModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onRequestClose: PropTypes.func.isRequired,
   fullAccessURL: PropTypes.string.isRequired,
+  readOnlyURL: PropTypes.string.isRequired,
 };
 
 export default ShareModal;

--- a/app/components/Toolbar.jsx
+++ b/app/components/Toolbar.jsx
@@ -7,14 +7,16 @@ const { bool, func, string } = PropTypes;
 const Toolbar = (props) =>
   <div id="toolbar">
     <div className="actions">
-      <button
-        className={`action share${props.enableShareModalButton ? '' : ' disabled'}`}
-        title="Share this document"
-        onClick={props.onToggleShareModal}
-        disabled={!props.enableShareModalButton}
-      >
-        <i className="fa fa-share-alt" aria-hidden="true" />
-      </button>
+      {false === props.readOnly ?
+        <button
+          className={`action share${props.enableShareModalButton ? '' : ' disabled'}`}
+          title="Share this document"
+          onClick={props.onToggleShareModal}
+          disabled={!props.enableShareModalButton}
+        >
+          <i className="fa fa-share-alt" aria-hidden="true" />
+        </button> : null
+      }
       <button
         className="action fullscreen"
         title="Presentation mode"
@@ -23,10 +25,12 @@ const Toolbar = (props) =>
         <i className="fa fa-play-circle" aria-hidden="true" />
       </button>
     </div>
-    <TemplateForm
-      template={props.template}
-      doUpdateTemplate={props.onUpdateTemplate}
-    />
+    {false === props.readOnly ?
+      <TemplateForm
+        template={props.template}
+        doUpdateTemplate={props.onUpdateTemplate}
+      /> : null
+    }
   </div>
 ;
 
@@ -36,6 +40,7 @@ Toolbar.propTypes = {
   onUpdateTemplate: func.isRequired,
   onToggleShareModal: func.isRequired,
   enableShareModalButton: bool.isRequired,
+  readOnly: bool.isRequired,
 };
 
 export default Toolbar;

--- a/app/components/__tests__/Header-test.js
+++ b/app/components/__tests__/Header-test.js
@@ -16,6 +16,9 @@ describe('<Header />', () => {
         onTogglePresentationMode={() => {}}
         template={''}
         onUpdateTemplate={() => {}}
+        onToggleShareModal={() => {}}
+        enableShareModalButton
+        readOnly={false}
       />
     );
     expect(wrapper.find('header')).to.have.length(1);

--- a/app/components/__tests__/Toolbar-test.js
+++ b/app/components/__tests__/Toolbar-test.js
@@ -16,7 +16,11 @@ describe('<Toolbar />', () => {
         onTogglePresentationMode={() => {}}
         template={''}
         onUpdateTemplate={() => {}}
-      />);
+        onToggleShareModal={() => {}}
+        enableShareModalButton
+        readOnly={false}
+      />
+    );
 
     expect(wrapper.find('#toolbar')).to.have.length(1);
   });

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { EventEmitter } from 'events';
 import localforage from 'localforage';
+import { Router, IndexRoute, Route, browserHistory } from 'react-router';
 
 import './scss/main.scss';
 
 import App from './components/App.jsx';
+import ReadOnly from './components/ReadOnly';
+import Editor from './components/Editor';
 import Store from './Store';
 import Controller from './Controller';
 
@@ -19,4 +22,12 @@ const controller = new Controller({ store }, events);
 
 require('offline-plugin/runtime').install();
 
-ReactDOM.render(<App version={appVersion} controller={controller} />, appElement);
+ReactDOM.render((
+  <Router history={browserHistory}>
+    <Route path="/" component={App} version={appVersion} controller={controller}>
+      <IndexRoute component={Editor} />
+      <Route path=":uuid" component={Editor} />
+      <Route path="r/:uuid" component={ReadOnly} />
+    </Route>
+  </Router>
+), appElement);

--- a/app/scss/components/_share_modal.scss
+++ b/app/scss/components/_share_modal.scss
@@ -19,7 +19,7 @@
   margin-right: -50%;
   padding: 1rem;
   transform: translate(-50%, -50%);
-  max-width: 400px;
+  max-width: 500px;
   border-radius: $global-radius;
   background-color: $primary-color;
   color: $white;
@@ -29,7 +29,7 @@
     margin-bottom: 2rem;
   }
 
-  h4, p {
+  h4, p, a {
     text-align: left;
     color: $white;
   }
@@ -40,6 +40,20 @@
 
   p {
     font-size: 1.1rem;
+  }
+
+  a {
+    color: darken($secondary-color, 5);
+
+    .i {
+      font-size: 0.9rem;
+    }
+  }
+
+  a:hover,
+  a:focus {
+    color: $white;
+    border-bottom: 1px solid $white;
   }
 
   .button {

--- a/lib/webpack-template.ejs
+++ b/lib/webpack-template.ejs
@@ -24,8 +24,5 @@
 <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
 <% } %>
 <% } %>
-<% if (htmlWebpackPlugin.options.devServer) { %>
-<script src="<%= htmlWebpackPlugin.options.devServer%>/webpack-dev-server.js"></script>
-<% } %>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-dom": "^15.3.0",
     "react-loader": "^2.1.0",
     "react-modal": "^1.4.0",
+    "react-router": "^2.6.1",
     "reveal.js": "^3.3.0",
     "sass-loader": "^4.0.0",
     "sinon": "^1.17.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,7 +55,8 @@ const common = {
     output: {
         path: PATHS.build,
         // `[name]` is replaced by the name of the chunk
-        filename: '[name].js'
+        filename: '[name].js',
+        publicPath: '/'
     },
     module: {
         // see: https://github.com/isagalaev/highlight.js/issues/895 and


### PR DESCRIPTION
cf. #148 / depends on: #171 
## Purpose

This PR is the result of my evening "hack session". The code is very hackish, but it seems to work. The idea is to demonstrate what we can do for #148. **But**, this PR does not cover any **safe** way to share Monod documents in read only.

This very first step is actually a "baby step", showing that we can display a Monod document either in an editor (current version) and in what I called a `ReadOnly` viewer. It uses the same Monod UUID and secret to display the document, hence it is easy to get access to the editor from the read only viewer. That is why it is not safe _per se_.

I need feedback!
## Features
- [x] Use React Router to deal with different "views"
- [x] Reuse as much code as possible
- [x] Make it work
- [x] Make it pretty
- [ ] Fix failling tests
- [ ] Refactor involved components to be more reusable
- [ ] Make it work better => tests ⚠️ 
## Share Modal

![screen shot 2016-08-09 at 22 27 37](https://cloud.githubusercontent.com/assets/217628/17532410/b485d8da-5e80-11e6-8b7f-08d6925e0795.png)
## Read Only View

![screen shot 2016-08-09 at 22 27 47](https://cloud.githubusercontent.com/assets/217628/17532404/ad8c16a2-5e80-11e6-9e0e-a950eda474f3.png)
