### PR TITLE
[WIP] File upload (w/ offline support)

### DIFF
--- a/app/components/Markdown/fold.js
+++ b/app/components/Markdown/fold.js
@@ -1,0 +1,41 @@
+/* eslint new-cap: 0 */
+import CodeMirror from 'codemirror';
+
+
+// We register a 'markdown' fold function so that is is automatically used by
+// CodeMirror as we set `gfm` as mode in the Markdown (React) component.
+CodeMirror.registerHelper('fold', 'markdown', (cm, start) => {
+  // link must be on a single line
+  const line = start.line;
+  const lineText = cm.getLine(line);
+
+  // find opening Markdown link
+  const index = lineText.lastIndexOf('](');
+
+  if (-1 === index) {
+    return null;
+  }
+
+  // check that it is an image, not an simple URL
+  if (!/\bimage\b/.test(cm.getTokenTypeAt(CodeMirror.Pos(line, index)))) {
+    return null;
+  }
+
+  const startCh = index + 2;
+
+  // check that the content we want to fold is an URL
+  if (!/\burl\b/.test(cm.getTokenTypeAt(CodeMirror.Pos(line, startCh)))) {
+    return null;
+  }
+
+  const endCh = lineText.indexOf(')');
+
+  if (-1 === endCh) {
+    return null;
+  }
+
+  return {
+    from: CodeMirror.Pos(line, startCh),
+    to: CodeMirror.Pos(line, endCh),
+  };
+});

--- a/app/components/Markdown/index.jsx
+++ b/app/components/Markdown/index.jsx
@@ -4,7 +4,6 @@ import Dropzone from 'react-dropzone';
 
 import 'codemirror/mode/gfm/gfm';
 import 'codemirror/lib/codemirror.css';
-import 'codemirror/addon/fold/foldgutter.css';
 import 'codemirror/addon/fold/foldcode';
 import 'codemirror/addon/fold/foldgutter';
 import './fold';

--- a/app/scss/components/_codemirror_theme.scss
+++ b/app/scss/components/_codemirror_theme.scss
@@ -38,3 +38,28 @@
         color: $primary-color;
     }
 }
+
+/* Fold gutter rules */
+.CodeMirror-foldmarker {
+  color: $gray;
+  font-family: arial;
+  line-height: .3;
+  cursor: pointer;
+}
+
+.CodeMirror-foldgutter {
+  width: .7em;
+}
+
+.CodeMirror-foldgutter-open,
+.CodeMirror-foldgutter-folded {
+  cursor: pointer;
+}
+
+.CodeMirror-foldgutter-open:after {
+  content: "\25BE";
+}
+
+.CodeMirror-foldgutter-folded:after {
+  content: "\25B8";
+}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react": "^15.3.1",
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",
+    "react-dropzone": "^3.5.3",
     "react-hot-loader": "^3.0.0-beta.1",
     "react-loader": "^2.1.0",
     "react-modal": "^1.4.0",

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ if ('production' === process.env.NODE_ENV || 'test' === process.env.NODE_ENV) {
   // middlewares
   app.use(compression());
   app.use(express.static(staticPath));
-  app.use(bodyParser.json());
+  app.use(bodyParser.json({limit: '3mb'}));
   app.use(api);
 
   const isValidId = (uuid) => {


### PR DESCRIPTION
## Purpose

The aim of this PR is to provide a way to add images to a Monod document by uploading local files to the document. Because we want to keep privacy (through encryption) and to guarantee offline-first mode, we serialize the images into base64 data URIs.

The main problem with this serialization mechanism is that it uses more space than a simple link... Therefore, we might think about optimizing the HTTP requests between Monod and its backend. Right now, it is out of scope of this PR.
## Features
- [x] Basic feature
- [x] Make it pretty
- [ ] Tests (but don't know how to test this)
## (Known) Limitations

There is a visual glitch right now because of the [CodeMirror `maxHighlightLength` option](https://codemirror.net/doc/manual.html#option_maxHighlightLength): the closing parenthesis is not highlighted because the data URI is longer than `maxHighlightLength` chars (10 000). We could "fix" this by setting `Infinity` but it will decrease performances.
## Screenshots

![out](https://cloud.githubusercontent.com/assets/217628/18161516/93d1e67e-7032-11e6-8712-96a6c63df501.gif)
