### PR TITLE
[WIP] Refresh panels when we change the editor mode

### DIFF
--- a/app/components/Editor/presenter.jsx
+++ b/app/components/Editor/presenter.jsx
@@ -19,24 +19,19 @@ export default class Editor extends Component {
     this.state = {
       position: 0,
       mode: EditorModes.PREVIEW,
+      refresh: false,
     };
 
     this.updatePosition = this.updatePosition.bind(this);
     this.handleOnClick = this.handleOnClick.bind(this);
   }
 
-  componentDidUpdate() {
-    if (window.Reveal) {
-      window.Reveal.layout();
-    }
-  }
-
   updatePosition(position) {
-    this.setState({ position });
+    this.setState({ position, refresh: false });
   }
 
   updateMode(newMode) {
-    this.setState({ mode: newMode });
+    this.setState({ mode: newMode, refresh: true });
   }
 
   handleOnClick(e) {
@@ -66,6 +61,7 @@ export default class Editor extends Component {
           onChange={this.props.onUpdateContent}
           onUpdatePosition={this.updatePosition}
           forceUpdate={this.props.forceUpdate}
+          refresh={this.state.refresh}
         />
         <VerticalHandler
           onClickLeft={this.handleOnClick}
@@ -76,6 +72,7 @@ export default class Editor extends Component {
           position={this.state.position}
           template={this.props.template}
           onClickCheckbox={this.props.onClickCheckbox}
+          refresh={this.state.refresh}
         />
       </Loader>
     );

--- a/app/components/Markdown/index.jsx
+++ b/app/components/Markdown/index.jsx
@@ -40,6 +40,13 @@ export default class Markdown extends Component {
     if (true === nextProps.forceUpdate && this.props.content !== nextProps.content) {
       this.getCodeMirror().setValue(nextProps.content);
     }
+
+    if (true === nextProps.refresh) {
+      const s = this.getCodeMirror().getSelection();
+
+      this.getCodeMirror().refresh();
+      this.getCodeMirror().setSelection(s);
+    }
   }
 
   shouldComponentUpdate() {
@@ -95,4 +102,9 @@ Markdown.propTypes = {
   onUpdatePosition: PropTypes.func.isRequired,
   // eslint rule disabled becasue false positive
   forceUpdate: PropTypes.bool.isRequired, // eslint-disable-line react/no-unused-prop-types
+  refresh: PropTypes.bool.isRequired, // eslint-disable-line react/no-unused-prop-types
+};
+
+Markdown.defaultProps = {
+  refresh: false,
 };

--- a/app/components/Preview/presenter.jsx
+++ b/app/components/Preview/presenter.jsx
@@ -79,6 +79,10 @@ class Preview extends Component {
       return;
     }
 
+    if (true === nextProps.refresh && window.Reveal) {
+      window.Reveal.layout();
+    }
+
     if (this.props.position !== nextProps.position || 1 === nextProps.position) {
       if (this.requestAnimationId) {
         window.cancelAnimationFrame(this.requestAnimationId);
@@ -217,10 +221,12 @@ Preview.propTypes = {
   position: PropTypes.number.isRequired,
   previewLoader: PropTypes.func.isRequired,
   onClickCheckbox: PropTypes.func.isRequired,
+  refresh: PropTypes.bool.isRequired, // eslint-disable-line react/no-unused-prop-types
 };
 
 Preview.defaultProps = {
   previewLoader,
+  refresh: false,
 };
 
 export default Preview;


### PR DESCRIPTION
## Purpose

There is a nasty bug that appears time to time when we change the editor mode
(focus, reading, split). The markdown editor panel is not aware of this change,
and the cursor is not correctly positionned.
