### PR TITLE
Add dynamic shortcut prefix

### DIFF
--- a/app/components/Markdown/__tests__/extra-keys-test.js
+++ b/app/components/Markdown/__tests__/extra-keys-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { Tags, addOrRemoveTag } from '../extra-keys';
+import { Tags, addOrRemoveTag, pre, mac } from '../extra-keys';
 
 // see: https://github.com/mochajs/mocha/issues/1847
 const { describe, it } = global;
@@ -38,5 +38,13 @@ This should not be strong**`;
     const result = addOrRemoveTag(Tags.STRONG, content);
 
     expect(result).to.equal('Hello\nThis should not be strong');
+  });
+
+  it('should properly set shortcut prefix', () => {
+    if (!mac) {
+      expect(pre).to.equal('Ctrl-');
+    } else {
+      expect(pre).to.equal('Cmd-');
+    }
   });
 });

--- a/app/components/Markdown/extra-keys.js
+++ b/app/components/Markdown/extra-keys.js
@@ -1,5 +1,9 @@
 import { saveAs } from 'file-saver';
+import codemirror from 'codemirror';
+import isEqual from 'lodash.isequal';
 
+const mac = isEqual(codemirror.keyMap.default, codemirror.keyMap.macDefault);
+const pre = mac ? 'Cmd-' : 'Ctrl-';
 
 export const Tags = {
   STRONG: '**',
@@ -21,19 +25,22 @@ export function addOrRemoveTag(tag, selection) {
   return `${tag}${selection}${tag}`;
 }
 
-const extraKeys = {
-  'Cmd-Z': (cm) => {
-    cm.undo();
-  },
-  'Cmd-B': (cm) => {
-    cm.replaceSelection(addOrRemoveTag(Tags.STRONG, cm.getSelection()), 'around');
-  },
-  'Cmd-I': (cm) => {
-    cm.replaceSelection(addOrRemoveTag(Tags.ITALIC, cm.getSelection()), 'around');
-  },
-  'Cmd-S': (cm) => {
-    saveAs(new Blob([cm.getValue()], { type: 'text/plain' }), 'monod.md');
-  },
+const extraKeys = {};
+
+extraKeys[`${pre}Z`] = (cm) => {
+  cm.undo();
+};
+
+extraKeys[`${pre}B`] = (cm) => {
+  cm.replaceSelection(addOrRemoveTag(Tags.STRONG, cm.getSelection()), 'around');
+};
+
+extraKeys[`${pre}I`] = (cm) => {
+  cm.replaceSelection(addOrRemoveTag(Tags.ITALIC, cm.getSelection()), 'around');
+};
+
+extraKeys[`${pre}S`] = (cm) => {
+  saveAs(new Blob([cm.getValue()], { type: 'text/plain' }), 'monod.md');
 };
 
 export default extraKeys;

--- a/app/components/Markdown/extra-keys.js
+++ b/app/components/Markdown/extra-keys.js
@@ -2,8 +2,8 @@ import { saveAs } from 'file-saver';
 import codemirror from 'codemirror';
 import isEqual from 'lodash.isequal';
 
-const mac = isEqual(codemirror.keyMap.default, codemirror.keyMap.macDefault);
-const pre = mac ? 'Cmd-' : 'Ctrl-';
+export const mac = isEqual(codemirror.keyMap.default, codemirror.keyMap.macDefault);
+export const pre = mac ? 'Cmd-' : 'Ctrl-';
 
 export const Tags = {
   STRONG: '**',


### PR DESCRIPTION
Fixes #249 

## Purpose
Adds dynamic shortcut prefixes so custom shortcuts can work on windows / mac. 

- `Cmd` now maps to `Ctrl` on Windows machines.

Since we pull in `codemirror` as a dependency, we can access the information they already store about a users' machine. Code duplication was necessary because codemirror does not export the `ctrl` value that they set.

I did need to change to using bracket-notation for the `extraKeys` object so that template strings could be used to set the dynamic prefixes. 

As a side note, I dev on windows & mac, and the npm scripts for the project do not work very well on a windows machine, I had to do some hacking around to get them to work properly. Might be worth throwing up an issue for that, but the shortcuts do work on Windows now 👍 