### PR TITLE
[WIP] Introduce named documents

### DIFF
--- a/app/Document.js
+++ b/app/Document.js
@@ -5,6 +5,7 @@ import config from './config';
 
 export default class Document extends Record({
   uuid: uuid.v4(),
+  name: config.DEFAULT_NAME,
   content: config.DEFAULT_CONTENT,
   last_modified: null, // defined by the server
   last_modified_locally: null,
@@ -30,5 +31,9 @@ export default class Document extends Record({
 
   isReadOnly() {
     return true === this.readonly;
+  }
+
+  getName() {
+    return this.name;
   }
 }

--- a/app/__tests__/fixtures/1e17761d-035a-4eb7-8aa7-48f1bc6e8a48
+++ b/app/__tests__/fixtures/1e17761d-035a-4eb7-8aa7-48f1bc6e8a48
@@ -4,5 +4,6 @@
     },
     "last_modified": 1459441561629,
     "uuid": "1e17761d-035a-4eb7-8aa7-48f1bc6e8a48",
-    "readonly": true
+    "readonly": true,
+    "name": ""
 }

--- a/app/__tests__/server-test.js
+++ b/app/__tests__/server-test.js
@@ -51,6 +51,7 @@ describe('Express app', () => {
           last_modified: 1459441561629,
           uuid: READONLY_DOCUMENT_UUID,
           readonly: true,
+          name: '',
         }, done);
     });
   });
@@ -108,7 +109,8 @@ describe('Express app', () => {
           content: content,
           uuid: NEW_DOCUMENT_UUID,
           template: '',
-          last_modified: 'date'
+          last_modified: 'date',
+          name: '',
         }, done);
     });
 
@@ -131,6 +133,7 @@ describe('Express app', () => {
           uuid: EXISTING_DOCUMENT_UUID,
           template: '',
           last_modified: 'date',
+          name: '',
         }, done);
     });
 
@@ -146,6 +149,7 @@ describe('Express app', () => {
           last_modified: 1459441561629,
           uuid: READONLY_DOCUMENT_UUID,
           readonly: true,
+          name: '',
         }, done);
     });
   });

--- a/app/components/Toolbar/InputName.jsx
+++ b/app/components/Toolbar/InputName.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+class InputName extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      name: props.name || '',
+    };
+
+    this.onChange = this.onChange.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
+  }
+
+  componentWillReceiveProps(newProps) {
+    const name = newProps.name;
+
+    if (this.state.name !== name) {
+      this.setState({ name });
+    }
+  }
+
+  onChange(event) {
+    const name = event.target.value;
+
+    this.setState({ name });
+  }
+
+  onKeyDown(event) {
+    if ('enter' === event.key.toLowerCase()) {
+      this.props.onUpdateName(this.state.name);
+    }
+  }
+
+  render() {
+    return (
+      <input
+        value={this.state.name}
+        onChange={this.onChange}
+        onKeyDown={this.onKeyDown}
+        className="input-name"
+        type="text"
+      />
+    );
+  }
+}
+
+InputName.propTypes = {
+  name: React.PropTypes.string.isRequired,
+  onUpdateName: React.PropTypes.func.isRequired,
+};
+
+export default InputName;

--- a/app/components/Toolbar/index.js
+++ b/app/components/Toolbar/index.js
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 import Toolbar from './presenter';
-import { updateTemplate } from '../../modules/documents';
+import { updateTemplate, updateDocumentName } from '../../modules/documents';
 
 
 const mapStateToProps = (state) => {
   const documents = state.documents;
 
   return {
+    name: documents.current.getName(),
     template: documents.current.template,
     enableShareModalButton: '' !== window.location.pathname.slice(1),
   };
@@ -17,6 +18,9 @@ const mapDispatchToProps = dispatch => ({
     const template = event.target.value;
 
     dispatch(updateTemplate(template));
+  },
+  onUpdateName: (name) => {
+    dispatch(updateDocumentName(name));
   },
 });
 

--- a/app/components/Toolbar/presenter.jsx
+++ b/app/components/Toolbar/presenter.jsx
@@ -3,10 +3,15 @@ import React, { PropTypes } from 'react';
 import TemplateForm from './TemplateForm';
 import FullscreenButton from './FullscreenButton';
 import ShareModalButton from './ShareModalButton';
+import InputName from './InputName';
 
 
 const Toolbar = props =>
   <div id="toolbar">
+    <InputName
+      name={props.name}
+      onUpdateName={props.onUpdateName}
+    />
     <div className="actions">
       <ShareModalButton
         onToggleShareModal={props.onToggleShareModal}
@@ -25,10 +30,12 @@ const Toolbar = props =>
 
 Toolbar.propTypes = {
   template: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   onUpdateTemplate: PropTypes.func.isRequired,
   onTogglePresentationMode: PropTypes.func.isRequired,
   onToggleShareModal: PropTypes.func.isRequired,
   enableShareModalButton: PropTypes.bool.isRequired,
+  onUpdateName: PropTypes.func.isRequired,
 };
 
 export default Toolbar;

--- a/app/config.js
+++ b/app/config.js
@@ -53,6 +53,7 @@ export default {
   ].join(' '),
 
   // in app/Document.js
+  DEFAULT_NAME: 'New Monod document',
   DEFAULT_CONTENT: [
     '---',
     'hello: world! # YAML Front Matter (for templates)',

--- a/app/modules/documents.js
+++ b/app/modules/documents.js
@@ -12,6 +12,7 @@ export const LOAD_SUCCESS = 'monod/documents/LOAD_SUCCESS';
 export const UPDATE_TEMPLATE = 'monod/documents/UPDATE_TEMPLATE';
 export const UPDATE_CONTENT = 'monod/documents/UPDATE_CONTENT';
 export const UPDATE_CURRENT_DOCUMENT = 'monod/documents/UPDATE_CURRENT_DOCUMENT';
+export const UPDATE_DOCUMENT_NAME = 'monod/documents/UPDATE_DOCUMENT_NAME';
 export const TOGGLE_TASK_LIST_ITEM = 'monod/documents/TOGGLE_TASK_LIST_ITEM';
 
 // Action Creators
@@ -27,9 +28,11 @@ export function loadSuccess(document, secret, skipSynchronize) {
   return (dispatch) => {
     dispatch({ type: LOAD_SUCCESS, document, secret });
 
-    window.history.pushState({}, 'Monod', `/${document.get('uuid')}#${secret}`);
+    const title = `${document.getName()} – Monod`;
+    window.history.pushState({}, title, `/${document.get('uuid')}#${secret}`);
+    window.document.title = title;
 
-    if (skipSynchronize !== true) {
+    if (true !== skipSynchronize) {
       dispatch(synchronize());
     }
   };
@@ -87,6 +90,17 @@ export function updateTemplate(template) {
     }
 
     return Promise.resolve();
+  };
+}
+
+export function updateDocumentName(name) {
+  return (dispatch) => {
+    const newName = name && '' !== name ? name : config.DEFAULT_NAME;
+
+    dispatch({ type: UPDATE_DOCUMENT_NAME, name: newName });
+    window.document.title = `${newName} – Monod`;
+
+    return dispatch(localPersist());
   };
 }
 
@@ -191,6 +205,15 @@ export default function reducer(state = initialState, action = {}) {
         ...state,
         current: state.current
           .set('content', action.content)
+          .set('last_modified_locally', Date.now()),
+        forceUpdate: false,
+      };
+
+    case UPDATE_DOCUMENT_NAME:
+      return {
+        ...state,
+        current: state.current
+          .set('name', action.name)
           .set('last_modified_locally', Date.now()),
         forceUpdate: false,
       };

--- a/app/modules/monod.js
+++ b/app/modules/monod.js
@@ -77,6 +77,7 @@ export function load(id, secret) {
             last_modified: res.body.last_modified,
             template: res.body.template || '', // avoid BC break
             readonly: res.body.readonly || false, // avoid BC break
+            name: res.body.name || '', // avoid BC break
           }));
         })
         .catch((err) => {

--- a/app/modules/persistence.js
+++ b/app/modules/persistence.js
@@ -66,6 +66,7 @@ export function serverPersist() {
       .send({
         content: encrypt(content, secret),
         template: document.get('template'),
+        name: document.get('name'),
       })
       .then((res) => {
         dispatch(isOnline());
@@ -77,6 +78,7 @@ export function serverPersist() {
           last_modified_locally: null,
           template: res.body.template || '',
           readonly: res.body.readonly || false,
+          name: res.body.name || '',
         });
 
         return Promise.resolve(current);
@@ -109,6 +111,7 @@ export function serverPersist() {
             last_modified_locally: null,
             template: res.body.template || '',
             readonly: res.body.readonly || false,
+            name: res.body.name || '',
           });
 
           dispatch(warning(config.READONLY_MESSAGE));

--- a/app/modules/sync.js
+++ b/app/modules/sync.js
@@ -67,6 +67,7 @@ export function synchronize() { // eslint-disable-line import/prefer-default-exp
           last_modified: res.body.last_modified,
           template: res.body.template || '', // avoid BC break
           readonly: res.body.readonly || false, // avoid BC break
+          name: res.body.name || '', // avoid BC break
         }));
       })
       .catch((err) => {
@@ -142,6 +143,7 @@ export function synchronize() { // eslint-disable-line import/prefer-default-exp
                 last_modified: serverDoc.get('last_modified'),
                 template: serverDoc.get('template'),
                 readonly: serverDoc.get('readonly'),
+                name: serverDoc.get('name'),
               });
 
               return db

--- a/app/scss/components/_header.scss
+++ b/app/scss/components/_header.scss
@@ -10,12 +10,15 @@ header.main {
   background-color: $primary-color;
 
   h1 {
-    flex-grow: 1;
+    flex: 1;
     padding: 0 1rem;
     color: $white;
+    overflow-x: hidden;
+    white-space: nowrap;
 
     small {
       color: darken($primary-color, 10%);
+      text-overflow: ellipsis;
     }
   }
 }

--- a/app/scss/components/_input_name.scss
+++ b/app/scss/components/_input_name.scss
@@ -1,0 +1,4 @@
+.input-name {
+  vertical-align: top;
+  width: 45%;
+}

--- a/app/scss/components/_toolbar.scss
+++ b/app/scss/components/_toolbar.scss
@@ -5,6 +5,7 @@
 #toolbar {
   text-align: right;
   padding: 1rem;
+  flex: 1;
 
   @include breakpoint(small only) {
     & {
@@ -23,12 +24,15 @@
   }
 
   @include breakpoint(medium down) {
+    flex: 0;
+
     .actions {
       .action.share {
         display: none;
       }
     }
-    #templateForm{
+    #templateForm,
+    .input-name {
       display: none;
     }
   }

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -38,6 +38,7 @@ $fa-font-path: '~font-awesome/fonts';
 @import 'components/sync';
 @import 'components/message_box';
 @import 'components/share_modal';
+@import 'components/input_name';
 
 // Utils
 @import 'utils/tooltips';

--- a/server.js
+++ b/server.js
@@ -74,6 +74,7 @@ if ('production' === process.env.NODE_ENV || 'test' === process.env.NODE_ENV) {
       document.content = req.body.content;
       document.last_modified = Date.now();
       document.template = req.body.template || '';
+      document.name = req.body.name || '';
 
       fs.writeFile(filename, JSON.stringify(document), (err) => {
         if (err) {


### PR DESCRIPTION
The idea of this PR is to add a name to Monod documents so that we can avoid to give them a name when bookmarking them, and also it should be ["unfurled"](https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254#.wmnm2lo1k) in Slack. That would be a huge improvement while searching info within Slack.

## TODO

- [x] Basic feature
- [ ] Make it work in Slack
- [ ] Add tests
- [ ] Refactor document update (maybe in a separate PR)