### PR TITLE
Typo in Letter template

### DIFF
--- a/app/components/Templates/Letter.jsx
+++ b/app/components/Templates/Letter.jsx
@@ -14,13 +14,13 @@ export default class Letter extends BaseTemplate {
       addressFrom: {
         name: '[addressFrom/name]',
         street: '[addressFrom/street]',
-        zipCode: '[addressFrom/zipcode]',
+        zipCode: '[addressFrom/zipCode]',
         city: '[addressFrom/city]',
       },
       addressTo: {
         name: '[addressTo/name]',
         street: '[addressTo/street]',
-        zipCode: '[addressTo/zipcode]',
+        zipCode: '[addressTo/zipCode]',
         city: '[addressTo/city]',
       },
       signature: '[signature]',


### PR DESCRIPTION
It is hard to guess that `zipCode` has an uppercase C when you write the default data after changing the template in Monod.
So, if we use a `C` instead of `c` it is easier to make it right for the first time.

I didn't updated the test suite because I'm not sure if it can break and I did the PR really quickly.